### PR TITLE
Add declaration_keyword configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ aliases:
   '_' => 'third-party-libs/underscore'
 ```
 
+### `declaration_keyword`
+
+If you are using ES6 (ES 2015), you have access to `let` and `const` in addition
+to `var` as ways to declare variables. To use one of these, set the
+`declaration_keyword` configuration.
+
+```yaml:
+declaration_keyword: const
+```
+
 ### `jshint_cmd`
 
 Configure a path to a `jshint` compatible command, e.g. `jsxhint`.

--- a/ruby/import-js/importer.rb
+++ b/ruby/import-js/importer.rb
@@ -16,6 +16,8 @@ module ImportJS
       end
     end
 
+    # Finds variable under the cursor to import. By default, this is bound to
+    # `<Leader>j`.
     def import
       variable_name = VIM.evaluate("expand('<cword>')")
       if variable_name.empty?
@@ -30,7 +32,7 @@ module ImportJS
       window.cursor = [current_row + lines_changed, current_col]
     end
 
-    # Finds variables that haven't yet been imported
+    # Finds all variables that haven't yet been imported.
     def import_all
       unused_variables = find_unused_variables
       imported_variables = []
@@ -54,6 +56,7 @@ module ImportJS
 
     private
 
+    # @return [Array]
     def find_unused_variables
       content = "/* jshint undef: true, strict: true */\n" +
                 VIM.evaluate('join(getline(1, "$"), "\n")')
@@ -68,6 +71,7 @@ module ImportJS
       result.uniq
     end
 
+    # @param variable_name [String]
     # @return the number of lines changed, or nil if no file was found for the
     #   variable.
     def import_one_variable(variable_name)
@@ -91,6 +95,8 @@ module ImportJS
       VIM::Window.current
     end
 
+    # @param variable_name [String]
+    # @param path_to_file [String]
     # @return [number] the number of lines changed
     def write_imports(variable_name, path_to_file)
       current_imports = find_current_imports
@@ -116,6 +122,7 @@ module ImportJS
       after_length - before_length
     end
 
+    # @return [Array]
     def find_current_imports
       lines = []
       buffer.count.times do |n|
@@ -126,6 +133,8 @@ module ImportJS
       lines
     end
 
+    # @param variable_name [String]
+    # @return [Array]
     def find_files(variable_name)
       if alias_path = @config['aliases'][variable_name]
         return [alias_path]
@@ -141,6 +150,9 @@ module ImportJS
       matched_files
     end
 
+    # @param files [Array]
+    # @param variable_name [String]
+    # @return [String]
     def resolve_one_file(files, variable_name)
       if files.length == 1
         VIM.message("[import-js] Imported `#{files.first}`")
@@ -158,6 +170,8 @@ module ImportJS
       files[selected_index - 1]
     end
 
+    # @param string [String]
+    # @return [String]
     def camelcase_to_snakecase(string)
       # Grabbed from
       # http://stackoverflow.com/questions/1509915/converting-camel-case-to-underscore-case-in-ruby

--- a/ruby/import-js/importer.rb
+++ b/ruby/import-js/importer.rb
@@ -21,8 +21,9 @@ module ImportJS
     def import
       variable_name = VIM.evaluate("expand('<cword>')")
       if variable_name.empty?
-        VIM.message(<<-EOS.strip)
-          [import-js]: No variable to import. Place your cursor on a variable, then try again.
+        VIM.message(<<-EOS.split.join(' '))
+          [import-js]: No variable to import. Place your cursor on a variable,
+          then try again.
         EOS
         return
       end
@@ -44,11 +45,11 @@ module ImportJS
       end
 
       if imported_variables.empty?
-        VIM.message(<<-EOS.strip)
+        VIM.message(<<-EOS.split.join(' '))
           [import-js]: No variables to import
         EOS
       else
-        VIM.message(<<-EOS.strip)
+        VIM.message(<<-EOS.split.join(' '))
           [import-js]: Imported these variables: #{imported_variables}
         EOS
       end
@@ -77,7 +78,9 @@ module ImportJS
     def import_one_variable(variable_name)
       files = find_files(variable_name)
       if files.empty?
-        VIM.message("[import-js]: No js file to import for variable `#{variable_name}`")
+        VIM.message(<<-EOS.split.join(' '))
+          [import-js]: No js file to import for variable `#{variable_name}`
+        EOS
         return
       end
 

--- a/ruby/import-js/importer.rb
+++ b/ruby/import-js/importer.rb
@@ -110,7 +110,12 @@ module ImportJS
 
       declaration_keyword = @config['declaration_keyword']
       current_imports << "#{declaration_keyword} #{variable_name} = require('#{path_to_file}');"
-      current_imports.sort!.uniq!
+
+      current_imports.sort!.uniq! do |import|
+        # Determine uniqueness by discarding the declaration keyword (`const`,
+        # `let`, or `var`).
+        import.sub(/\A(const|let|var)\s+/, '')
+      end
 
       current_imports.reverse.each do |import_line|
         buffer.append(0, import_line)
@@ -130,7 +135,7 @@ module ImportJS
       lines = []
       buffer.count.times do |n|
         line = buffer[n + 1]
-        break unless line.match(/^var\s+.+=\s+require\(.*\).*;\s*$/)
+        break unless line.match(/^(const|let|var)\s+.+=\s+require\(.*\).*;\s*$/)
         lines << line
       end
       lines

--- a/ruby/import-js/importer.rb
+++ b/ruby/import-js/importer.rb
@@ -5,9 +5,10 @@ module ImportJS
   class Importer
     def initialize
       @config = {
-        'lookup_paths' => ['.'],
         'aliases' => {},
-        'jshint_cmd' => 'jshint'
+        'declaration_keyword' => 'var',
+        'jshint_cmd' => 'jshint',
+        'lookup_paths' => ['.'],
       }
       config_file = '.importjs'
       if File.exist? config_file
@@ -98,7 +99,7 @@ module ImportJS
         buffer.delete(1)
       end
 
-      declaration_keyword = @config['declaration_keyword'] || 'var'
+      declaration_keyword = @config['declaration_keyword']
       current_imports << "#{declaration_keyword} #{variable_name} = require('#{path_to_file}');"
       current_imports.sort!.uniq!
 

--- a/ruby/import-js/importer.rb
+++ b/ruby/import-js/importer.rb
@@ -98,7 +98,8 @@ module ImportJS
         buffer.delete(1)
       end
 
-      current_imports << "var #{variable_name} = require('#{path_to_file}');"
+      declaration_keyword = @config['declaration_keyword'] || 'var'
+      current_imports << "#{declaration_keyword} #{variable_name} = require('#{path_to_file}');"
       current_imports.sort!.uniq!
 
       current_imports.reverse.each do |import_line|

--- a/spec/import-js/importer_spec.rb
+++ b/spec/import-js/importer_spec.rb
@@ -273,6 +273,31 @@ $
         EOS
         end
       end
+
+      context 'with declaration_keyword' do
+        subject do
+          ImportJS::Importer.new.import
+          VIM::Buffer.current_buffer.to_s
+        end
+
+        let(:configuration) do
+          {
+            'declaration_keyword' => 'const'
+          }
+        end
+
+        context 'with a variable name that will resolve' do
+          let(:resolved_files) { ['bar/foo.js.jsx'] }
+
+          it 'adds an import to the top of the buffer using the declaration_keyword' do
+            expect(subject).to eq(<<-EOS.strip)
+const foo = require('bar/foo');
+
+foo
+            EOS
+          end
+        end
+      end
     end
   end
 

--- a/spec/import-js/importer_spec.rb
+++ b/spec/import-js/importer_spec.rb
@@ -296,6 +296,41 @@ const foo = require('bar/foo');
 foo
             EOS
           end
+
+          context 'when that variable is already imported using `var`' do
+            let(:text) { <<-EOS.strip }
+var foo = require('bar/foo');
+
+foo
+            EOS
+
+            it 'changes the `var` to declaration_keyword' do
+              expect(subject).to eq(<<-EOS.strip)
+const foo = require('bar/foo');
+
+foo
+              EOS
+            end
+          end
+
+          context 'when other imports exist' do
+            let(:text) { <<-EOS.strip }
+var zoo = require('foo/zoo');
+let bar = require('foo/bar');
+
+foo
+            EOS
+
+            it 'adds the import and sorts the entire list' do
+              expect(subject).to eq(<<-EOS.strip)
+const foo = require('bar/foo');
+let bar = require('foo/bar');
+var zoo = require('foo/zoo');
+
+foo
+            EOS
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
If you are using ES6 (ES 2015), you have access to `let` and `const` in
addition to `var` as ways to declare variables. `const` seems like an
appropriate declaration keyword to use when requiring modules, so it
would be nice if this plugin supports it.

This commit adds support for a `declaration_keyword` option that can be
set to a string that will be used instead of `var` when declaring the
variables that are assigned to the required modules.