### PR TITLE
Add .projections.json

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -1,0 +1,10 @@
+{
+  "ruby/import-js/*.rb": {
+    "alternate": "spec/import-js/{}_spec.rb",
+    "type": "source"
+  },
+  "spec/import-js/*_spec.rb": {
+    "alternate": "ruby/import-js/{}.rb",
+    "type": "test"
+  }
+}


### PR DESCRIPTION
This configuration help plugins like vim-projectionist work. With this
file, I can now run `:A` in Vim to jump between the Ruby source file and the
spec file, making it easier to work with this project.