### PR TITLE
Remove Ruby 1.8.7 from Travis, add 2.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - "1.8.7"
   - "1.9.3"
   - "2.1.1"
+  - "2.2.1"
 
 script: rspec
 install: gem install rspec


### PR DESCRIPTION
This project uses Ruby syntax that was introduced in 1.9.0. Furthermore,
Ruby 1.8.7 was EOL'd in June 2013. It doesn't seem valuable to run tests
against this version of Ruby anymore.

https://www.ruby-lang.org/en/news/2013/06/30/we-retire-1-8-7/