### PR TITLE
Add support for imports with line-breaks

### DIFF
--- a/ruby/import-js/importer.rb
+++ b/ruby/import-js/importer.rb
@@ -124,14 +124,16 @@ module ImportJS
 
       # Delete old imports, then add the modified list back in.
       current_imports[:newline_count].times { buffer.delete(1) }
-      imports.reverse.each { |import| buffer.append(0, import) }
+      imports.reverse_each do |import|
+        import.split("\n").reverse_each { |line| buffer.append(0, line) }
+      end
 
       # Consumers of this method rely on knowing how many lines of code
       # changed, so we return that.
       imports.length - before_length
     end
 
-    # @return [Array]
+    # @return [Hash]
     def find_current_imports
       imports_blob = ''
       buffer.count.times do |n|

--- a/ruby/import-js/importer.rb
+++ b/ruby/import-js/importer.rb
@@ -104,14 +104,9 @@ module ImportJS
     def write_imports(variable_name, path_to_file)
       current_imports = find_current_imports
 
+      # Add a newline after imports
       unless buffer[current_imports[:newline_count] + 1].strip.empty?
-        # Add a newline after imports
         buffer.append(current_imports[:newline_count], '')
-      end
-
-      # delete current imports
-      current_imports[:newline_count].times do
-        buffer.delete(1)
       end
 
       imports = current_imports[:imports]
@@ -127,12 +122,13 @@ module ImportJS
         import.sub(/\A(const|let|var)\s+/, '').sub(/\s\s+/s, ' ')
       end
 
-      # add imports back in
-      imports.reverse.each do |import_line|
-        buffer.append(0, import_line)
-      end
+      # Delete old imports, then add the modified list back in.
+      current_imports[:newline_count].times { buffer.delete(1) }
+      imports.reverse.each { |import| buffer.append(0, import) }
 
-      imports.length - before_length # truthy if the import was new
+      # Consumers of this method rely on knowing how many lines of code
+      # changed, so we return that.
+      imports.length - before_length
     end
 
     # @return [Array]

--- a/spec/import-js/importer_spec.rb
+++ b/spec/import-js/importer_spec.rb
@@ -157,6 +157,27 @@ foo
         end
       end
 
+      context 'when there is an import with line-breaks' do
+        let(:text) { <<-EOS.strip }
+var zoo =
+  require('foo/zoo');
+var tsar = require('foo/bar').tsar;
+
+var foo = { require: b }
+        EOS
+
+        it 'adds the import, sorts the entire list and keeps the line-break' do
+          expect(subject).to eq(<<-EOS.strip)
+var foo = require('bar/foo');
+var tsar = require('foo/bar').tsar;
+var zoo =
+  require('foo/zoo');
+
+var foo = { require: b }
+        EOS
+        end
+      end
+
       context 'when there is a blank line amongst current imports' do
         let(:text) { <<-EOS.strip }
 var zoo = require('foo/zoo');
@@ -305,6 +326,23 @@ foo
             EOS
 
             it 'changes the `var` to declaration_keyword' do
+              expect(subject).to eq(<<-EOS.strip)
+const foo = require('bar/foo');
+
+foo
+              EOS
+            end
+          end
+
+          context 'when the import contains a line-break' do
+            let(:text) { <<-EOS.strip }
+var foo =
+  require('bar/foo');
+
+foo
+            EOS
+
+            it 'changes the `var` to declaration_keyword and removes the whitespace' do
               expect(subject).to eq(<<-EOS.strip)
 const foo = require('bar/foo');
 


### PR DESCRIPTION
As reported by @lencioni in #9:

  If I have a section of required modules at the top that looks like this:

    const MyModule = require('path/to/my_module');
    const MyModuleThatHasALongName =
      require('path/to/my_module_that_has_a_long_name');
    const SomeModule = require('path/to/some_module');

  import-js gets confused when adding a new module to the list:

    const AnotherModule = require('path/to/another_module');
    const MyModule = require('path/to/my_module');

    const MyModuleThatHasALongName =
      require('path/to/my_module_that_has_a_long_name');
    const SomeModule = require('path/to/some_module');

  where I would expect:

    const AnotherModule = require('path/to/another_module');
    const MyModule = require('path/to/my_module');
    const MyModuleThatHasALongName =
      require('path/to/my_module_that_has_a_long_name');
    const SomeModule = require('path/to/some_module');

  It would be nice if import-js worked better with this format.

I've added basic support for line breaks in this commit. I say basic
because I expect there to be edge cases that I haven't thought of.
We use simple regexs to parse the js file content, and like all simple
regex parsers, they are bound to fail. However, I don't want to bring in
a js parsing framework just yet. So in this commit I extend the regex
approach with some logic to deal with possible line-breaks.

One idea also listed in #9 was to add support for import-js to
automatically line-break long lines. I haven't made that change in this
commit (new imports are still one-line), but I might do that later if I
find time.