### PR TITLE
Make mock buffer behave more like a real buffer

### DIFF
--- a/spec/import-js/mock_vim_buffer.rb
+++ b/spec/import-js/mock_vim_buffer.rb
@@ -8,7 +8,9 @@ class MockVimBuffer
   end
 
   def append(index, string)
-    @buffer_lines.insert(index, string)
+    # We replace newlines with "^@" because that's what a real vim buffer will
+    # output if you append such a string.
+    @buffer_lines.insert(index, string.gsub("\n", '^@'))
   end
 
   def count


### PR DESCRIPTION
If you try to append a string with \n newline characters in it, a real
vim buffer will output "^@" in place of the newline characters. The
mock buffer that we've been using didn't do that which led to a bug
fixed in https://github.com/trotzig/import-js/commit/5f91595aa4. Making
the mock behave more like a real buffer will prevent us from making this
mistake again.

Fixes #13