### PR TITLE
Use Vim settings for wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,6 @@ Configure a path to a `jshint` compatible command, e.g. `jsxhint`.
 jshint_cmd: jsxhint
 ```
 
-### `text_width`
-
-Configure the maximum line length before wrapping occurs. Defaults to `80`.
-
-```yaml
-text_width: 80
-```
-
 ## Dependencies
 
 import-js is written in Ruby, so in order to make it work in your Vim you need

--- a/ruby/import-js/importer.rb
+++ b/ruby/import-js/importer.rb
@@ -9,7 +9,6 @@ module ImportJS
         'declaration_keyword' => 'var',
         'jshint_cmd' => 'jshint',
         'lookup_paths' => ['.'],
-        'text_width' => 80,
       }
       config_file = '.importjs'
       if File.exist? config_file
@@ -100,6 +99,29 @@ module ImportJS
       VIM::Window.current
     end
 
+    # Check for the presence of a setting such as:
+    #
+    #   - g:CommandTSmartCase (plug-in setting)
+    #   - &wildignore         (Vim setting)
+    #   - +cursorcolumn       (Vim setting, that works)
+    #
+    # @param str [String]
+    # @return [Boolean]
+    def exists?(str)
+      VIM.evaluate(%{exists("#{str}")}).to_i != 0
+    end
+
+    # @param name [String]
+    # @return [Number?]
+    def get_number(name)
+      exists?(name) ? VIM.evaluate("#{name}").to_i : nil
+    end
+
+    # @return [Number?]
+    def text_width
+      get_number('&textwidth')
+    end
+
     # @param variable_name [String]
     # @param path_to_file [String]
     # @return [Boolean] true if a variable was imported, false if not
@@ -160,11 +182,10 @@ module ImportJS
     # @return [String] the import string to be added to the imports block
     def generate_import(variable_name, path_to_file)
       declaration_keyword = @config['declaration_keyword']
-      text_width = @config['text_width']
       declaration = "#{declaration_keyword} #{variable_name} ="
       value = "require('#{path_to_file}');"
 
-      if "#{declaration} #{value}".length > text_width
+      if text_width && "#{declaration} #{value}".length > text_width
         # TODO: configurable indentation
         "#{declaration}\n  #{value}"
       else

--- a/ruby/import-js/importer.rb
+++ b/ruby/import-js/importer.rb
@@ -117,9 +117,32 @@ module ImportJS
       exists?(name) ? VIM.evaluate("#{name}").to_i : nil
     end
 
+    # @param name [String]
+    # @return [Boolean?]
+    def get_bool(name)
+      exists?(name) ? VIM.evaluate("#{name}").to_i != 0 : nil
+    end
+
     # @return [Number?]
     def text_width
       get_number('&textwidth')
+    end
+
+    # @return [Boolean?]
+    def expand_tab?
+      get_bool('&expandtab')
+    end
+
+    # @return [Number?]
+    def shift_width
+      get_number('&shiftwidth')
+    end
+
+    # @return [String] shiftwidth number of spaces if expandtab is not set,
+    #   otherwise `\t`
+    def tab
+      return "\t" unless expand_tab?
+      ' ' * (shift_width || 2)
     end
 
     # @param variable_name [String]
@@ -186,8 +209,7 @@ module ImportJS
       value = "require('#{path_to_file}');"
 
       if text_width && "#{declaration} #{value}".length > text_width
-        # TODO: configurable indentation
-        "#{declaration}\n  #{value}"
+        "#{declaration}\n#{tab}#{value}"
       else
         "#{declaration} #{value}"
       end

--- a/spec/import-js/importer_spec.rb
+++ b/spec/import-js/importer_spec.rb
@@ -286,13 +286,55 @@ foo
 
         let(:resolved_files) { ['fiz/bar/biz/baz/fiz/buz/boz/foo.js.jsx'] }
 
-        it 'wraps them' do
-          expect(subject).to eq(<<-EOS.strip)
+        context 'when expandtab is not set' do
+          before(:each) do
+            allow(importer).to receive(:expand_tab?).and_return(false)
+          end
+
+          it 'wraps them and indents with a tab' do
+            expect(subject).to eq(<<-EOS.strip)
+var foo =
+	require('fiz/bar/biz/baz/fiz/buz/boz/foo');
+
+foo
+            EOS
+          end
+        end
+
+        context 'when expandtab is set' do
+          before(:each) do
+            allow(importer).to receive(:expand_tab?).and_return(true)
+          end
+
+          context 'when shiftwidth is set' do
+            before(:each) do
+              allow(importer).to receive(:shift_width).and_return(3)
+            end
+
+            it 'wraps them and indents with shiftwidth spaces' do
+              expect(subject).to eq(<<-EOS.strip)
+var foo =
+   require('fiz/bar/biz/baz/fiz/buz/boz/foo');
+
+foo
+              EOS
+            end
+          end
+
+          context 'when shiftwidth is not set' do
+            before(:each) do
+              allow(importer).to receive(:shift_width).and_return(nil)
+            end
+
+            it 'wraps them and indents with 2 spaces' do
+              expect(subject).to eq(<<-EOS.strip)
 var foo =
   require('fiz/bar/biz/baz/fiz/buz/boz/foo');
 
 foo
-          EOS
+              EOS
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Instead of requiring people to add configuration to their `.importjs` file, we can just lean on the configuration they have already set up for Vim by looking at `textwidth`, `expandtab`, and `shiftwidth` to get perfectly consistent line wrapping and indentation. No muss, no fuss.