### PR TITLE
Improve ESLint compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ to `var` as ways to declare variables. To use one of these, set the
 
 ### `jshint_cmd`
 
-Configure a path to a `jshint` compatible command, e.g. `jsxhint`.
+Configure a path to a `jshint` compatible command, e.g. `jsxhint` or `eslint`.
 
 ```json
 "jshint_cmd": "jsxhint"

--- a/ruby/import_js/importer.rb
+++ b/ruby/import_js/importer.rb
@@ -50,6 +50,7 @@ module ImportJS
     # @return [Array]
     def find_unused_variables
       content = "/* jshint undef: true, strict: true */\n" +
+                "/* eslint no-unused-vars: [2, { \"vars\": \"all\", \"args\": \"none\" }]\n" +
                 VIM.evaluate('join(getline(1, "$"), "\n")')
 
       out, _ = Open3.capture3("#{@config.get('jshint_cmd')} -", stdin_data: content)


### PR DESCRIPTION
We are using a JSHint configuration comment to ensure that the settings
we need to find unused variables is enabled, but we weren't doing
anything similar for folks who are using ESLint. To make sure that this
will work regardless of a project's ESLint configuration, I am adding a
similar config comment to enable the rule that we are relying on for
this feature. I disabled it checking args for this because those don't
matter for this use case and I assume that disabling it will make it
faster.

I wonder if we can get some more performance by disabling all rules but
the one that we need, but that will have to wait for another time.