### PR TITLE
Match modules following node.js naming conventions

### DIFF
--- a/ruby/import_js/importer.rb
+++ b/ruby/import_js/importer.rb
@@ -168,16 +168,14 @@ module ImportJS
       matched_files = []
       @config.get('lookup_paths').each do |lookup_path|
         Dir.chdir(lookup_path) do
-          matched_files.
-            # Look for files named similar to the variable
-            concat(Dir.glob("**/#{regex_variable}.js*", File::FNM_CASEFOLD)).
-            # Look for modules following the node.js convention of
-            # module_name/index.js
-            concat(Dir.glob("**/#{regex_variable}/index.js*", File::FNM_CASEFOLD))
+          Dir.glob('**/*.js*') do |filename|
+            if filename.match(%r{(/|^)#{regex_variable}(/index)?\.js.*}i)
+              matched_files << filename
+            end
+          end
         end
       end
-
-      matched_files.select { |element| element.match(/#{regex_variable.gsub('*', '.?')}/i) }
+      matched_files
     end
 
     # @param files [Array]
@@ -214,9 +212,8 @@ module ImportJS
       # Based on
       # http://stackoverflow.com/questions/1509915/converting-camel-case-to-underscore-case-in-ruby
       string.
-        gsub(/::/, '/'). # converts '::' to '/'
-        gsub(/([a-z\d])([A-Z])/, '\1*\2'). # separates camelCase words with '*'
-        tr('-_', '*'). # replaces underscores or dashes with '*'
+        gsub(/([a-z\d])([A-Z])/, '\1.?\2'). # separates camelCase words with '.?'
+        tr('-_', '.'). # replaces underscores or dashes with '.'
         downcase # converts all upper to lower case
     end
   end

--- a/ruby/import_js/importer.rb
+++ b/ruby/import_js/importer.rb
@@ -149,7 +149,7 @@ module ImportJS
     def generate_import(variable_name, path_to_file)
       declaration_keyword = @config.get('declaration_keyword')
       declaration = "#{declaration_keyword} #{variable_name} ="
-      value = "require('#{path_to_file}');"
+      value = "require('#{path_to_file.sub(/\/index$/, '')}');"
 
       if @config.text_width && "#{declaration} #{value}".length > @config.text_width
         "#{declaration}\n#{@config.tab}#{value}"
@@ -169,12 +169,15 @@ module ImportJS
       @config.get('lookup_paths').each do |lookup_path|
         Dir.chdir(lookup_path) do
           matched_files.
-            concat(Dir.glob("**/#{regex_variable}.js*", File::FNM_CASEFOLD).
-            select { |element| element.match(/#{regex_variable.gsub('*', '.?')}/i) })
+            # Look for files named similar to the variable
+            concat(Dir.glob("**/#{regex_variable}.js*", File::FNM_CASEFOLD)).
+            # Look for modules following the node.js convention of
+            # module_name/index.js
+            concat(Dir.glob("**/#{regex_variable}/index.js*", File::FNM_CASEFOLD))
         end
       end
 
-      matched_files
+      matched_files.select { |element| element.match(/#{regex_variable.gsub('*', '.?')}/i) }
     end
 
     # @param files [Array]


### PR DESCRIPTION
At Brigade, we've started using a component-centric structure for our
React code base. This means that everything that belongs to a component
(scss code, tests, jsx code) is stored in one folder. E.g.

-- Button
   |
   |-- index.jsx
   |-- index.scss
   |-- index-test.jsx

We want ImportJS to find the index.jsx files, and import it in the
following way:

  const Button = require('<path_to_modules>/Button');

I made a first naive implementation by adding another Dir.glob, looking
for anything with the module name and ending in index.js*. The previous
post-processing filter was enough to rule out any mismatched files.

I understand that this introduces a performance penalty. I intend to
follow up by making the Dir.glob call even more broad, and let the
post-processing filter take care of reducing even further.