### PR TITLE
Improve performance by using native `find` and `egrep`

### DIFF
--- a/ruby/import_js/importer.rb
+++ b/ruby/import_js/importer.rb
@@ -2,7 +2,6 @@ module ImportJS
   class Importer
     def initialize
       @config = ImportJS::Configuration.new
-      @cache = {}
      end
 
     # Finds variable under the cursor to import. By default, this is bound to
@@ -167,44 +166,20 @@ module ImportJS
       if alias_path = @config.get('aliases')[variable_name]
         return [alias_path]
       end
-      regex_variable = formatted_to_regex(variable_name)
+
+      egrep_command =
+        "egrep -i \"(/|^)#{formatted_to_regex(variable_name)}(/index)?\.js.*\""
       matched_files = []
       @config.get('lookup_paths').each do |lookup_path|
-        find_js_files_for_path(lookup_path).each do |filename|
-          if filename.match(%r{(/|^)#{regex_variable}(/index)?\.js.*}i)
-            matched_files << filename
+        find_command = "find #{lookup_path} -name \"**.js*\""
+        out, _ = Open3.capture3("#{find_command} | #{egrep_command}")
+        matched_files.concat(
+          out.split("\n").map do |f|
+            f.sub("#{lookup_path}\/", '') # remove path prefix
           end
-        end
+        )
       end
-      matched_files
-    end
-
-    # @param path [String]
-    # @return [Array]
-    def find_js_files_for_path(path)
-      cached_files = @cache[path]
-      if cached_files && !path_modified_since?(path, cached_files[:timestamp])
-        return cached_files[:files]
-      end
-
-      Dir.chdir(path) do
-        cached_files = {
-          files: Dir.glob('**/*.js*'),
-          timestamp: Time.now
-        }
-      end
-      @cache[path] = cached_files
-      cached_files[:files]
-    end
-
-    # @param path [String]
-    # @param time [Time]
-    # @return [Boolean]
-    def path_modified_since?(path, time)
-      seconds_since_time = Time.now.to_i - time.to_i
-      Open3.popen3('find', path, '-type', 'd', '-mtime', "-#{seconds_since_time}s") do |_, out|
-        !out.read.empty?
-      end
+      matched_files.sort
     end
 
     # @param files [Array]


### PR DESCRIPTION
As I was profiling importing files on a fairly large (Brigade) codebase,
I found a couple of interesting things:

  a) The `Dir.glob` call used to find all .js* files was taking about
     0.2 seconds.
  b) The loop to find exactly those files to import took about 0.4
     seconds too.
  c) The check to see if anything had changed (file added/removed) in a
     directory took about 0.1 seconds.
  d) In total, an import would take between 0.6 and 0.7 seconds,
     independent of whether the cache was used or not.

My previous attempt at improving performance through a cache layer
didn't make too much of a difference, because I was optimizing (a). I
should have tried to optimize (b) instead if I had been smart. This
second attempt at improving performance, addresses both (a) and (b) by
delegating the `Dir.glob` to a external `find` command, and the
filtering loop to an external `egrep` command. This takes importing
times down to under 0.2 seconds on my laptop, so about three times
faster than before, and without any complicated cache.