### PR TITLE
Fix bug with aliases with slashes

### DIFF
--- a/ruby/import_js/js_module.rb
+++ b/ruby/import_js/js_module.rb
@@ -26,7 +26,10 @@ module ImportJS
           @import_path.sub!(/\.js.*$/, '')
         end
       end
-      @import_path = @import_path.sub("#{@lookup_path}\/", '') # remove path prefix
+
+      if lookup_path
+        @import_path = @import_path.sub("#{@lookup_path}\/", '') # remove path prefix
+      end
     end
 
     # @return [String] a readable description of the module

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -568,6 +568,24 @@ var $ = require('jquery');
 $
         EOS
         end
+
+        context 'and an alias contains a slash' do
+          # https://github.com/trotzig/import-js/issues/39
+          let(:configuration) do
+            {
+              'aliases' => { '$' => 'jquery/jquery' }
+            }
+          end
+
+          it 'keeps the slash in the alias path' do
+            expect(subject).to eq(<<-EOS.strip)
+var $ = require('jquery/jquery');
+
+$
+          EOS
+          end
+
+        end
       end
 
       context 'when keep_file_extensions is true' do


### PR DESCRIPTION
The way I was (ab)using the JSModule class for aliases proved to have an
issue if an alias contained a slash. Fixing that temporarily now by
avoiding the problematic code path, but I might revisit to keep aliases
completely outside the JSModule class.

Fixes #39