### PR TITLE
Allow aliases to contain destructured objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,29 @@ those, you can add them to the `aliases` configuration.
 }
 ```
 
+If you have a library that expose a single object that has a bunch of objects
+on it that you want to use, you can list those in a `destructure` array inside
+the alias (which then has to be turned into an object):
+
+```json
+"aliases": {
+  "$": "third-party-libs/jquery",
+  "_": {
+    "path": "third-party-libs/underscore",
+    "destructure": ["memoize", "debounce"]
+  }
+}
+```
+
+Imports then use [ES6 Destructuring Assigment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment),
+e.g.
+
+```javascript
+const { memoize } = require('underscore');
+
+memoize(() => { foo() });
+```
+
 ### `declaration_keyword`
 
 If you are using ES6 (ES 2015), you have access to `let` and `const` in addition

--- a/ruby/import_js/configuration.rb
+++ b/ruby/import_js/configuration.rb
@@ -23,6 +23,28 @@ module ImportJS
       @config[key]
     end
 
+    def resolve_alias(variable_name)
+      path = @config['aliases'][variable_name]
+      return resolve_destructured_alias(variable_name) unless path
+
+      if path.is_a? Hash
+        path = path['path']
+      end
+      ImportJS::JSModule.new(nil, path, self)
+    end
+
+    def resolve_destructured_alias(variable_name)
+      @config['aliases'].each do |_, path|
+        next if path.is_a? String
+        if (path['destructure'] || []).include?(variable_name)
+          js_module = ImportJS::JSModule.new(nil, path['path'], self)
+          js_module.is_destructured = true
+          return js_module
+        end
+      end
+      nil
+    end
+
     # @return [Number?]
     def text_width
       get_number('&textwidth')

--- a/ruby/import_js/importer.rb
+++ b/ruby/import_js/importer.rb
@@ -153,7 +153,11 @@ module ImportJS
     # @return [String] the import string to be added to the imports block
     def generate_import(variable_name, js_module)
       declaration_keyword = @config.get('declaration_keyword')
-      declaration = "#{declaration_keyword} #{variable_name} ="
+      if js_module.is_destructured
+        declaration = "#{declaration_keyword} { #{variable_name} } ="
+      else
+        declaration = "#{declaration_keyword} #{variable_name} ="
+      end
       value = "require('#{js_module.import_path}');"
 
       if @config.text_width && "#{declaration} #{value}".length > @config.text_width
@@ -166,8 +170,8 @@ module ImportJS
     # @param variable_name [String]
     # @return [Array]
     def find_js_modules(variable_name)
-      if alias_path = @config.get('aliases')[variable_name]
-        return [ImportJS::JSModule.new(nil, alias_path, @config)]
+      if alias_module = @config.resolve_alias(variable_name)
+        return [alias_module]
       end
 
       egrep_command =

--- a/ruby/import_js/js_module.rb
+++ b/ruby/import_js/js_module.rb
@@ -4,11 +4,12 @@ module ImportJS
     attr_reader :import_path
     attr_reader :main_file
     attr_reader :skip
+    attr_accessor :is_destructured
 
     # @param lookup_path [String] the lookup path in which this module was found
     # @param relative_file_path [String] a full path to the file, relative to
-    # @param configuration [ImportJS::Configuration]
     #   the project root.
+    # @param configuration [ImportJS::Configuration]
     def initialize(lookup_path, relative_file_path, configuration)
       @lookup_path = lookup_path
       if relative_file_path.end_with? '/package.json'

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -588,6 +588,45 @@ $
         end
       end
 
+      context 'alias with a destructure object' do
+        let(:configuration) do
+          {
+            'aliases' => {
+              '_' => {
+                'path' => 'underscore',
+                'destructure' => %w(
+                  memoize
+                  debounce
+                )
+              }
+            }
+          }
+        end
+        let(:text) { '_' }
+        let(:word) { '_' }
+
+        it 'resolves the main alias without destructuring' do
+          expect(subject).to eq(<<-EOS.strip)
+var _ = require('underscore');
+
+_
+        EOS
+        end
+
+        context 'when importing a destructured object' do
+          let(:text) { 'memoize' }
+          let(:word) { 'memoize' }
+
+          it 'resolves that import in a destructured way' do
+            expect(subject).to eq(<<-EOS.strip)
+var { memoize } = require('underscore');
+
+memoize
+            EOS
+          end
+        end
+      end
+
       context 'when keep_file_extensions is true' do
         let(:existing_files) { ['bar/foo.js'] }
         let(:configuration) do


### PR DESCRIPTION
This is useful if you are using a library that exports a single object
but that objects has properties (objects, methods) that we want to
single out in our import. Here's an example with Underscore.js:

  const { memoize } = require('underscore')

  memoize(() => { doSomethingExpensive() })

The feature requests mentions combining multiple destructured objects
into one, but that turned out to be a little bit too involved for the
time I have available. A future enhancement could make sure that
multiple destructured objects are combined into one:

  const { memoize, debounce } = require('underscore');

Fixes #38