### PR TITLE
Auto-reload configuration

### DIFF
--- a/ruby/import_js/configuration.rb
+++ b/ruby/import_js/configuration.rb
@@ -12,9 +12,14 @@ module ImportJS
     'lookup_paths' => ['.'],
   }
 
-  # Class that initializes configuration from a .importjs file
+  # Class that initializes configuration from a .importjs.json file
   class Configuration
     def initialize
+      @config = DEFAULT_CONFIG.merge(load_config)
+    end
+
+    def refresh
+      return if @config_time == config_file_last_modified
       @config = DEFAULT_CONFIG.merge(load_config)
     end
 
@@ -61,7 +66,13 @@ module ImportJS
 
     # @return [Hash]
     def load_config
+      @config_time = config_file_last_modified
       File.exist?(CONFIG_FILE) ? JSON.parse(File.read(CONFIG_FILE)) : {}
+    end
+
+    # @return [Time?]
+    def config_file_last_modified
+      File.exist?(CONFIG_FILE) ? File.mtime(CONFIG_FILE) : nil
     end
 
     # Check for the presence of a setting such as:

--- a/ruby/import_js/importer.rb
+++ b/ruby/import_js/importer.rb
@@ -10,6 +10,7 @@ module ImportJS
     # Finds variable under the cursor to import. By default, this is bound to
     # `<Leader>j`.
     def import
+      @config.refresh
       variable_name = VIM.evaluate("expand('<cword>')")
       if variable_name.empty?
         VIM.message(<<-EOS.split.join(' '))
@@ -28,6 +29,7 @@ module ImportJS
 
     # Finds all variables that haven't yet been imported.
     def import_all
+      @config.refresh
       unused_variables = find_unused_variables
 
       if unused_variables.empty?

--- a/spec/import_js/configuration_spec.rb
+++ b/spec/import_js/configuration_spec.rb
@@ -3,33 +3,65 @@ require 'json'
 
 describe 'Configuration' do
   let(:key) { 'aliases' }
-  subject   { ImportJS::Configuration.new.get(key) }
+  subject   { ImportJS::Configuration.new }
 
-  describe 'with a configuration file' do
+  describe '.refresh' do
     let(:configuration) do
       {
         'aliases' => { 'foo' => 'bar' }
       }
     end
 
+    let(:time) { Time.new }
+
     before do
       allow(File).to receive(:exist?).with('.importjs.json').and_return(true)
       allow(File).to receive(:read).and_return nil
+      allow(File).to receive(:mtime).and_return time
       allow(JSON).to receive(:parse).and_return(configuration)
+      subject
     end
 
-    it 'returns the configured value for the key' do
-      expect(subject).to eq('foo' => 'bar')
+    it 'does not read the file again if it has not changed' do
+      expect(File).to receive(:read).exactly(0).times
+      subject.refresh
+    end
+
+    it 'reads the file again if it has changed' do
+      allow(File).to receive(:mtime).and_return time + 1
+      expect(File).to receive(:read).once
+      subject.refresh
     end
   end
 
-  describe 'without a configuration file' do
-    before do
-      allow(File).to receive(:exist?).with('.importjs.json').and_return(false)
+  describe '.get' do
+    describe 'with a configuration file' do
+      let(:configuration) do
+        {
+          'aliases' => { 'foo' => 'bar' }
+        }
+      end
+
+      before do
+        allow(File).to receive(:exist?).with('.importjs.json').and_return(true)
+        allow(File).to receive(:read).and_return nil
+        allow(File).to receive(:mtime).and_return nil
+        allow(JSON).to receive(:parse).and_return(configuration)
+      end
+
+      it 'returns the configured value for the key' do
+        expect(subject.get(key)).to eq('foo' => 'bar')
+      end
     end
 
-    it 'returns the default value for the key' do
-      expect(subject).to eq({})
+    describe 'without a configuration file' do
+      before do
+        allow(File).to receive(:exist?).with('.importjs.json').and_return(false)
+      end
+
+      it 'returns the default value for the key' do
+        expect(subject.get(key)).to eq({})
+      end
     end
   end
 end


### PR DESCRIPTION
I find that whenever I modify the .importjs.json file, I need to restart
Vim before the new settings take effect. It would be nice if I the
settings were just reloaded without needing to restart Vim.

Fixes #44