### PR TITLE
Fix bug with organizing imports

### DIFF
--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -220,6 +220,36 @@ foo
         end
       end
 
+      context 'when there is a non-import inline with the imports' do
+        let(:text) { <<-EOS.strip }
+var bar = require('bar');
+var star =
+  require('star');
+var { STRAWBERRY, CHOCOLATE } = bar.scoops;
+var zoo = require('foo/zoo');
+
+foo
+        EOS
+
+        it 'breaks imports at that line' do
+          # A better solution would perhaps be to find the `var zoo` import and
+          # move it up there with the rest. But there's a lot of complexity
+          # involved in that, so cutting off at the non-import is a simpler
+          # solution.
+          expect(subject).to eq(<<-EOS.strip)
+var bar = require('bar');
+var foo = require('bar/foo');
+var star =
+  require('star');
+
+var { STRAWBERRY, CHOCOLATE } = bar.scoops;
+var zoo = require('foo/zoo');
+
+foo
+        EOS
+        end
+      end
+
       context 'when there is an import with line-breaks' do
         let(:text) { <<-EOS.strip }
 var zoo =


### PR DESCRIPTION
If you had a buffer that looked something like this

  var a = require('a');
  var b = a.b;
  var c = require('c');

the buffer would be changed to this on successful import:

  var a = require('a');
  var c = require('c');

  var b = a.b;
  var c = require('c');

Notice the duplicate `c` import. The bug was probably introduced in
1cc2157 when I added support for multiline imports. I change the code in
find_current_imports to stop scanning for imports if it finds something
that is not an import. The result is that import-js will become better
at breaking off the list of imports from the rest of top-level
initialization, but if you start mixin imports and regular assignment at
the top you might be surprised with the result. For instance, the
example shown above will result in this output (let's pretend that
you're importing `d` here):

  var a = require('a');
  var d = require('d');

  var b = a.b;
  var c = require('c');

This output is partly a result of what was easy to implement, and a
future enhancement might change the implementation to generate this
output instead (again, let's pretend we're importing `d`):

  var a = require('a');
  var c = require('c');
  var d = require('d');

  var b = a.b;