### PR TITLE
Dedupe modules when lookup_paths overlap

### DIFF
--- a/ruby/import_js/importer.rb
+++ b/ruby/import_js/importer.rb
@@ -210,7 +210,15 @@ module ImportJS
           end.compact
         )
       end
-      matched_modules.uniq { |m| m.import_path }.sort do |a, b|
+
+      # If you have overlapping lookup paths, you might end up seeing the same
+      # module to import twice. In order to dedupe these, we remove the module
+      # with the longest path
+      matched_modules.sort do |a, b|
+        a.import_path.length <=> b.import_path.length
+      end.uniq do |m|
+        m.lookup_path + '/' + m.import_path
+      end.sort do |a, b|
         a.display_name <=> b.display_name
       end
     end

--- a/ruby/import_js/js_module.rb
+++ b/ruby/import_js/js_module.rb
@@ -2,6 +2,7 @@ module ImportJS
   # Class that represents a js module found in the file system
   class JSModule
     attr_reader :import_path
+    attr_reader :lookup_path
     attr_reader :main_file
     attr_reader :skip
     attr_accessor :is_destructured


### PR DESCRIPTION
At Brigade, we have two lookup_paths that overlap:

  app/assets
  app/assets/javascripts

When you try to import a module in `app/assets/javascripts`, you get two
options:

  [import-js] Pick js module to import for 'warn': (0.24s)
  1: javascripts/lib/warn
  2: lib/warn

The overlapping lookup paths are for many reasons not ideal, but
changing this structure isn't a straightforward change. So I've decided
to do something about it in import-js instead.

Assuming that we always want the shorter import path (`lib/warn` in the
example above), we first sort modules by import path length, then dedupe
modules. This will remove the module(s) with the longer path(s). We then
sort again, to get consistent alphabetic sorting in the selection list.