### PR TITLE
Add :ImportJSGoTo to quickly open a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,18 @@ lookup to see where in the file system that button component was located.
 
 If you use [jshint](http://jshint.com/) or
 [jsxhint](https://github.com/STRML/JSXHint/) import-js can be used to
-automatically import all undefined variables. Just type `:ImportJSImportAll`,
-and all your variables will be resolved. By default, import-js expects a global
-`jshint` command to be available. You can override that through the
-`jshint_cmd` configuration option.
+automatically import all undefined variables. Just type `:ImportJSImportAll`
+(or hit `<leader>i`), and all your variables will be resolved. By default,
+import-js expects a global `jshint` command to be available. You can override
+that through the `jshint_cmd` configuration option.
+
+## Experimental: Go to module
+
+Since Import-JS is pretty good at finding js modules, it makes sense that
+there's an option to open/go to a file rather than import it. This is similar
+to VIM's built in ["Open file under
+cursor"](http://vim.wikia.com/wiki/Open_file_under_cursor). Use it by placing
+the cursor on a variable and type `:ImportJSGoTo`, or hit `<leader>g`.
 
 ## Things to note
 

--- a/autoload/importjs.vim
+++ b/autoload/importjs.vim
@@ -4,6 +4,9 @@ endfunction
 function importjs#ImportJSImportAll()
   ruby $import_js.import_all
 endfunction
+function importjs#ImportJSGoTo()
+  ruby $import_js.goto
+endfunction
 
 ruby << EOF
   begin

--- a/plugin/import-js.vim
+++ b/plugin/import-js.vim
@@ -5,6 +5,7 @@ let g:import_js_loaded = 1
 
 command ImportJSImport call importjs#ImportJSImport()
 command ImportJSImportAll call importjs#ImportJSImportAll()
+command ImportJSGoTo call importjs#ImportJSGoTo()
 
 if !hasmapto(':ImportJSImport<CR>') && maparg('<Leader>j', 'n') == ''
   silent! nnoremap <unique> <silent> <Leader>j :ImportJSImport<CR>
@@ -12,4 +13,8 @@ endif
 
 if !hasmapto(':ImportJSImportAll<CR>') && maparg('<Leader>i', 'n') == ''
   silent! nnoremap <unique> <silent> <Leader>i :ImportJSImportAll<CR>
+endif
+
+if !hasmapto(':ImportJSGoTo<CR>') && maparg('<Leader>g', 'n') == ''
+  silent! nnoremap <unique> <silent> <Leader>g :ImportJSGoTo<CR>
 endif

--- a/ruby/import_js/importer.rb
+++ b/ruby/import_js/importer.rb
@@ -27,6 +27,17 @@ module ImportJS
       window.cursor = [current_row + lines_changed, current_col]
     end
 
+    def goto
+      @config.refresh
+      @timing = { start: Time.now }
+      variable_name = VIM.evaluate("expand('<cword>')")
+      js_modules = find_js_modules(variable_name)
+      @timing[:end] = Time.now
+      return if js_modules.empty?
+      js_module = resolve_one_js_module(js_modules, variable_name)
+      VIM.command("e #{js_module.file_path}")
+    end
+
     # Finds all variables that haven't yet been imported.
     def import_all
       @config.refresh

--- a/ruby/import_js/js_module.rb
+++ b/ruby/import_js/js_module.rb
@@ -3,6 +3,7 @@ module ImportJS
   class JSModule
     attr_reader :import_path
     attr_reader :lookup_path
+    attr_reader :file_path
     attr_reader :main_file
     attr_reader :skip
     attr_accessor :is_destructured
@@ -13,6 +14,7 @@ module ImportJS
     # @param configuration [ImportJS::Configuration]
     def initialize(lookup_path, relative_file_path, configuration)
       @lookup_path = lookup_path
+      @file_path = relative_file_path
       if relative_file_path.end_with? '/package.json'
         @main_file = JSON.parse(File.read(relative_file_path))['main']
         match = relative_file_path.match(/(.*)\/package\.json/)
@@ -25,7 +27,7 @@ module ImportJS
       else
         @import_path = relative_file_path
         unless configuration.get('keep_file_extensions')
-          @import_path.sub!(/\.js.*$/, '')
+          @import_path = @import_path.sub(/\.js.*$/, '')
         end
       end
 


### PR DESCRIPTION
This is something that I've wanted to try for a while. Since Import-JS
is already pretty good at resolving a variable name to a file, we might
as well add an option to quickly go to (open) that file.

This feature is still experimental. I haven't added any tests, and if
you end up having to resolve multiple modules in a selection list, the
copy will talk about "importing" that variable. If this feature plays
out well, I might polish it.

Now, some might say "just use `gf`". That's certainly an option, it's
just that I find it tricky to configure correctly. And it wasn't hard to
implement in import-js (I know that's not a great reason for adding
features in general though...).