### PR TITLE
Truncate messages to prevent having to confirm

### DIFF
--- a/autoload/importjs.vim
+++ b/autoload/importjs.vim
@@ -8,6 +8,17 @@ function importjs#ImportJSGoTo()
   ruby $import_js.goto
 endfunction
 
+" WideMsg() prints [long] message up to (&columns-1) length
+" guaranteed without "Press Enter" prompt.
+" http://vim.wikia.com/wiki/How_to_print_full_screen_width_messages
+function! importjs#WideMsg(msg)
+  let x=&ruler | let y=&showcmd
+  set noruler noshowcmd
+  redraw
+  echo a:msg
+  let &ruler=x | let &showcmd=y
+endfun
+
 ruby << EOF
   begin
     require 'import_js'

--- a/ruby/import_js/configuration.rb
+++ b/ruby/import_js/configuration.rb
@@ -32,9 +32,7 @@ module ImportJS
       path = @config['aliases'][variable_name]
       return resolve_destructured_alias(variable_name) unless path
 
-      if path.is_a? Hash
-        path = path['path']
-      end
+      path = path['path'] if path.is_a? Hash
       ImportJS::JSModule.new(nil, path, self)
     end
 
@@ -48,6 +46,11 @@ module ImportJS
         end
       end
       nil
+    end
+
+    # @return [Number?]
+    def columns
+      get_number('&columns')
     end
 
     # @return [Number?]

--- a/ruby/import_js/importer.rb
+++ b/ruby/import_js/importer.rb
@@ -15,8 +15,8 @@ module ImportJS
       variable_name = VIM.evaluate("expand('<cword>')")
       if variable_name.empty?
         message(<<-EOS.split.join(' '))
-          [import-js]: No variable to import. Place your cursor on a variable,
-          then try again.
+          No variable to import. Place your cursor on a variable, then try
+          again.
         EOS
         return
       end
@@ -45,9 +45,7 @@ module ImportJS
       unused_variables = find_unused_variables
 
       if unused_variables.empty?
-        message(<<-EOS.split.join(' '))
-          [import-js]: No variables to import
-        EOS
+        message('No variables to import')
         return
       end
 
@@ -59,6 +57,7 @@ module ImportJS
     private
 
     def message(str)
+      str = "[import-js] #{str}"
       str = str[0...(@config.columns - 1)] + '…' if str.length > @config.columns
       VIM.message(str)
     end
@@ -86,7 +85,7 @@ module ImportJS
       @timing[:end] = Time.now
       if js_modules.empty?
         message(<<-EOS.split.join(' '))
-          [import-js]: No js module to import for variable `#{variable_name}` #{timing}
+          No js module to import for variable `#{variable_name}` #{timing}
         EOS
         return
       end
@@ -245,7 +244,7 @@ module ImportJS
     # @return [String]
     def resolve_one_js_module(js_modules, variable_name)
       if js_modules.length == 1
-        message("[import-js] Imported `#{js_modules.first.display_name}` #{timing}")
+        message("Imported `#{js_modules.first.display_name}` #{timing}")
         return js_modules.first
       end
 

--- a/ruby/import_js/importer.rb
+++ b/ruby/import_js/importer.rb
@@ -13,7 +13,7 @@ module ImportJS
       @config.refresh
       variable_name = VIM.evaluate("expand('<cword>')")
       if variable_name.empty?
-        VIM.message(<<-EOS.split.join(' '))
+        message(<<-EOS.split.join(' '))
           [import-js]: No variable to import. Place your cursor on a variable,
           then try again.
         EOS
@@ -44,7 +44,7 @@ module ImportJS
       unused_variables = find_unused_variables
 
       if unused_variables.empty?
-        VIM.message(<<-EOS.split.join(' '))
+        message(<<-EOS.split.join(' '))
           [import-js]: No variables to import
         EOS
         return
@@ -56,6 +56,10 @@ module ImportJS
     end
 
     private
+
+    def message(str)
+      VIM.message(str)
+    end
 
     # @return [Array]
     def find_unused_variables
@@ -79,7 +83,7 @@ module ImportJS
       js_modules = find_js_modules(variable_name)
       @timing[:end] = Time.now
       if js_modules.empty?
-        VIM.message(<<-EOS.split.join(' '))
+        message(<<-EOS.split.join(' '))
           [import-js]: No js module to import for variable `#{variable_name}` #{timing}
         EOS
         return
@@ -239,7 +243,7 @@ module ImportJS
     # @return [String]
     def resolve_one_js_module(js_modules, variable_name)
       if js_modules.length == 1
-        VIM.message("[import-js] Imported `#{js_modules.first.display_name}` #{timing}")
+        message("[import-js] Imported `#{js_modules.first.display_name}` #{timing}")
         return js_modules.first
       end
 

--- a/ruby/import_js/importer.rb
+++ b/ruby/import_js/importer.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'json'
 require 'open3'
 
@@ -5,7 +6,7 @@ module ImportJS
   class Importer
     def initialize
       @config = ImportJS::Configuration.new
-     end
+    end
 
     # Finds variable under the cursor to import. By default, this is bound to
     # `<Leader>j`.
@@ -58,6 +59,7 @@ module ImportJS
     private
 
     def message(str)
+      str = str[0...(@config.columns - 1)] + '…' if str.length > @config.columns
       VIM.message(str)
     end
 

--- a/ruby/import_js/importer.rb
+++ b/ruby/import_js/importer.rb
@@ -58,8 +58,11 @@ module ImportJS
 
     def message(str)
       str = "[import-js] #{str}"
-      str = str[0...(@config.columns - 1)] + '…' if str.length > @config.columns
-      VIM.message(str)
+      if str.length > @config.columns - 1
+        str = str[0...(@config.columns - 2)] + '…'
+      end
+
+      VIM.command(":call importjs#WideMsg('#{str}')")
     end
 
     # @return [Array]

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -107,7 +107,7 @@ describe 'Importer' do
       it 'displays a message' do
         subject
         expect(VIM.last_message).to start_with(
-          "[import-js]: No js module to import for variable `#{word}`")
+          "[import-js] No js module to import for variable `#{word}`")
       end
     end
 
@@ -121,7 +121,7 @@ describe 'Importer' do
       it 'displays a message' do
         subject
         expect(VIM.last_message).to eq(
-          '[import-js]: No variable to import. Place your cursor on a variable, then try again.')
+          '[import-js] No variable to import. Place your cursor on a variable, then try again.')
       end
 
       context 'when Vim is narrower than the message' do
@@ -133,7 +133,7 @@ describe 'Importer' do
         it 'truncates the message' do
           subject
           expect(VIM.last_message).to eq(
-            '[import-js]: No variable to import. Place your cursor on a variable, then try a…')
+            '[import-js] No variable to import. Place your cursor on a variable, then try ag…')
         end
       end
     end
@@ -758,7 +758,7 @@ foo
         it 'displays a message' do
           subject
           expect(VIM.last_message).to start_with(
-            "[import-js]: No js module to import for variable `#{word}`")
+            "[import-js] No js module to import for variable `#{word}`")
         end
       end
 
@@ -862,7 +862,7 @@ foo
       it 'displays a message' do
         subject
         expect(VIM.last_message).to eq(
-          '[import-js]: No variables to import'
+          '[import-js] No variables to import'
         )
       end
     end

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 require 'tmpdir'
 require 'pathname'
@@ -72,6 +73,8 @@ describe 'Importer' do
       .to receive(:get).and_call_original
     allow_any_instance_of(ImportJS::Configuration)
       .to receive(:get).with('lookup_paths').and_return([@tmp_dir])
+    allow_any_instance_of(ImportJS::Configuration)
+      .to receive(:columns).and_return(100)
 
     existing_files.each do |file|
       full_path = File.join(@tmp_dir, file)
@@ -119,6 +122,19 @@ describe 'Importer' do
         subject
         expect(VIM.last_message).to eq(
           '[import-js]: No variable to import. Place your cursor on a variable, then try again.')
+      end
+
+      context 'when Vim is narrower than the message' do
+        before do
+          allow_any_instance_of(ImportJS::Configuration)
+            .to receive(:columns).and_return(80)
+        end
+
+        it 'truncates the message' do
+          subject
+          expect(VIM.last_message).to eq(
+            '[import-js]: No variable to import. Place your cursor on a variable, then try a…')
+        end
       end
     end
 

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -26,12 +26,16 @@ describe 'Importer' do
         end
       end
 
-      def self.message(message)
-        @last_message = message
+      def self.command(command)
+        @last_command = command
       end
 
-      def self.last_message
-        @last_message
+      def self.last_command
+        @last_command
+      end
+
+      def self.last_command_message
+        @last_command.gsub(/^:call importjs#WideMsg\('(.*?)'\)/, '\1')
       end
 
       def self.last_inputlist
@@ -106,7 +110,7 @@ describe 'Importer' do
 
       it 'displays a message' do
         subject
-        expect(VIM.last_message).to start_with(
+        expect(VIM.last_command_message).to start_with(
           "[import-js] No js module to import for variable `#{word}`")
       end
     end
@@ -120,7 +124,7 @@ describe 'Importer' do
 
       it 'displays a message' do
         subject
-        expect(VIM.last_message).to eq(
+        expect(VIM.last_command_message).to eq(
           '[import-js] No variable to import. Place your cursor on a variable, then try again.')
       end
 
@@ -132,8 +136,8 @@ describe 'Importer' do
 
         it 'truncates the message' do
           subject
-          expect(VIM.last_message).to eq(
-            '[import-js] No variable to import. Place your cursor on a variable, then try ag…')
+          expect(VIM.last_command_message).to eq(
+            '[import-js] No variable to import. Place your cursor on a variable, then try a…')
         end
       end
     end
@@ -150,7 +154,7 @@ foo
       end
 
       it 'displays a message about the imported module' do
-        expect(VIM.last_message).to start_with(
+        expect(VIM.last_command_message).to start_with(
           '[import-js] Imported `bar/foo`')
       end
 
@@ -178,7 +182,7 @@ foo
         end
 
         it 'displays a message about the imported module' do
-          expect(VIM.last_message).to start_with(
+          expect(VIM.last_command_message).to start_with(
             '[import-js] Imported `Foo (main: index.js.jsx)`')
         end
 
@@ -757,7 +761,7 @@ foo
 
         it 'displays a message' do
           subject
-          expect(VIM.last_message).to start_with(
+          expect(VIM.last_command_message).to start_with(
             "[import-js] No js module to import for variable `#{word}`")
         end
       end
@@ -861,7 +865,7 @@ foo
 
       it 'displays a message' do
         subject
-        expect(VIM.last_message).to eq(
+        expect(VIM.last_command_message).to eq(
           '[import-js] No variables to import'
         )
       end


### PR DESCRIPTION
Sometimes, when you're importing a module with a long name/path to, Vim
isn't wide enough to display the full message. In those cases, you have
to hit Enter in order to continue doing what you were doing in the file.

In this commit I fix this by looking at the width of Vim and
automatically truncating any messages being displayed.

Fixes #48