### PR TITLE
Import directly via package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ looks like this:
 document.createElement(new Button({ text: 'Save' }).toDOMElement());
 ```
 
-At this point, `Button` is undefined, we need to import it. You begin by
+At this point, `Button` is undefined. We need to import it. You begin by
 placing your cursor on "Button". Then hit `<leader>j` (or enter
 `:ImportJSImport`). The Vim buffer changes to the following:
 
 ```js
 var Button = require('components/button');
+
 document.createElement(new Button({ text: 'Save' }).toDOMElement());
 ```
 
@@ -62,7 +63,8 @@ the cursor on a variable and type `:ImportJSGoTo`, or hit `<leader>g`.
 ## Things to note
 
 - Only files ending in .js\* are considered when importing
-- All imports are expressed on one line each, starting with `var`
+- All imports are expressed on one line each, starting with `var`/`const`/`let`
+  (configurable)
 - As part of resolving an import, all imports will be sorted
 - The plugin is written in Ruby. You need a Vim with Ruby support.
 
@@ -79,19 +81,21 @@ Webpack, these should match the `modulesDirectories` configuration. Example:
 ```json
 "lookup_paths": [
   "app/assets/javascripts",
-  "vendor/bower_components"
+  "react-components"
 ]
 ```
+
+*Tip:* Don't put `node_modules` here. Import-JS will find your Node
+dependencies through your `package.json` file.
 
 ### `excludes`
 
 Define a list of glob patterns that match files and directories that you don't
-want to include for importing. This could be e.g. nested dependencies to any
-direct dependency you have.
+want to include for importing.
 
 ```json
 "excludes": [
-  "node_modules/**/node_modules/**"
+  "react-components/**/test/**"
 ]
 ```
 

--- a/ruby/import_js/configuration.rb
+++ b/ruby/import_js/configuration.rb
@@ -65,6 +65,19 @@ module ImportJS
       ' ' * (shift_width || 2)
     end
 
+    # @return [Array<String>]
+    def package_dependencies
+      return [] unless File.exist?('package.json')
+
+      package = JSON.parse(File.read('package.json'))
+      dependencies = package['dependencies'] ?
+        package['dependencies'].keys : []
+      peer_dependencies = package['peerDependencies'] ?
+        package['peerDependencies'].keys : []
+
+      dependencies.concat(peer_dependencies)
+    end
+
     private
 
     # @return [Hash]

--- a/ruby/import_js/importer.rb
+++ b/ruby/import_js/importer.rb
@@ -230,6 +230,15 @@ module ImportJS
         )
       end
 
+      # Find imports from package.json
+      @config.package_dependencies.each do |dep|
+        next unless dep =~ /^#{formatted_to_regex(variable_name)}$/
+        js_module = ImportJS::JSModule.new(
+          'node_modules', "node_modules/#{dep}/package.json", @config)
+        next if js_module.skip
+        matched_modules << js_module
+      end
+
       # If you have overlapping lookup paths, you might end up seeing the same
       # module to import twice. In order to dedupe these, we remove the module
       # with the longest path


### PR DESCRIPTION
As your node_modules directory grows, it can become harder to prevent
the wrong modules from being imported. Npm will automatically flatten
sub-dependencies (foo depends on bar, baz depends on bar) into top-level
modules, and it isn't easy to spot that an import is using such an
indirect dependency. You might see this in your project

  const alpha = require('alpha');

even though "alpha" is not listed as a dependency in your packages.json
file.

To prevent this from happening, and to make import-js more closely tied
to package.json, import-js will now parse package.json for
"dependencies" and "peerDependencies" and import such modules if they
match the variable to import (given that they have a `main` module
defined inside their package.json).

A positive side-effect from this change is that performance is way
better now that we don't have to traverse the entire node_modules
folder.

It is recommended that you remove `node_modules` from the lookup path if
you have a package.json file to describe your dependencies. If you
don't, you won't get the benefits outlined in this commit (importing
will still work though).

Fixes #43