### PR TITLE
Use %q{...} instead of "..." for eslint config comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ that through the `jshint_cmd` configuration option.
 
 ## Experimental: Go to module
 
-Since Import-JS is pretty good at finding js modules, it makes sense that
+Since Import-JS is pretty good at finding JS modules, it makes sense that
 there's an option to open/go to a file rather than import it. This is similar
 to VIM's built in ["Open file under
 cursor"](http://vim.wikia.com/wiki/Open_file_under_cursor). Use it by placing
@@ -154,7 +154,7 @@ Configure a path to a `jshint` compatible command, e.g. `jsxhint` or `eslint`.
 
 ### `keep_file_extensions`
 
-Set to true to make Import-JS keep the file extension of the imported js file.
+Set to true to make Import-JS keep the file extension of the imported JS file.
 E.g. `const Foo = require('foo.js')`.
 
 ```json

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -24,7 +24,8 @@ module ImportJS
 
       old_buffer_lines = @editor.count_lines
       import_one_variable variable_name
-      return unless lines_changed = @editor.count_lines - old_buffer_lines
+      lines_changed = @editor.count_lines - old_buffer_lines
+      return unless lines_changed
       @editor.cursor = [current_row + lines_changed, current_col]
     end
 
@@ -82,10 +83,8 @@ module ImportJS
       js_modules = find_js_modules(variable_name)
       @timing[:end] = Time.now
       if js_modules.empty?
-        message(<<-EOS.split.join(' '))
-          No js module to import for variable `#{variable_name}` #{timing}
-        EOS
-        return
+        return message(
+          "No js module to import for variable `#{variable_name}` #{timing}")
       end
 
       resolved_js_module = resolve_one_js_module(js_modules, variable_name)
@@ -167,6 +166,7 @@ module ImportJS
       newline_count = imports.length + imports.reduce(0) do |sum, import|
         sum + import.scan(/\n/).length
       end
+
       {
         imports: imports,
         newline_count: newline_count
@@ -249,7 +249,7 @@ module ImportJS
 
       selected_index = @editor.ask_for_selection(
         "\"ImportJS: Pick js module to import for '#{variable_name}': #{timing}\"",
-        js_modules.map {|m| m.display_name}
+        js_modules.map(&:display_name)
       )
       return unless selected_index
       js_modules[selected_index]

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -63,7 +63,7 @@ module ImportJS
     # @return [Array]
     def find_unused_variables
       content = "/* jshint undef: true, strict: true */\n" +
-                "/* eslint no-unused-vars: [2, { \"vars\": \"all\", \"args\": \"none\" }] */\n" +
+                %q{/* eslint no-unused-vars: [2, { "vars": "all", "args": "none" }] */\n} +
                 @editor.current_file_content
 
       out, _ = Open3.capture3("#{@config.get('jshint_cmd')} -", stdin_data: content)

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -84,7 +84,7 @@ module ImportJS
       @timing[:end] = Time.now
       if js_modules.empty?
         return message(
-          "No js module to import for variable `#{variable_name}` #{timing}")
+          "No JS module to import for variable `#{variable_name}` #{timing}")
       end
 
       resolved_js_module = resolve_one_js_module(js_modules, variable_name)
@@ -248,7 +248,7 @@ module ImportJS
       end
 
       selected_index = @editor.ask_for_selection(
-        "\"ImportJS: Pick js module to import for '#{variable_name}': #{timing}\"",
+        "\"ImportJS: Pick JS module to import for '#{variable_name}': #{timing}\"",
         js_modules.map(&:display_name)
       )
       return unless selected_index

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -111,7 +111,7 @@ describe 'Importer' do
       it 'displays a message' do
         subject
         expect(VIM.last_command_message).to start_with(
-          "ImportJS: No js module to import for variable `#{word}`")
+          "ImportJS: No JS module to import for variable `#{word}`")
       end
     end
 
@@ -350,7 +350,7 @@ foo
         it 'displays a message about selecting a module' do
           subject
           expect(VIM.last_inputlist).to include(
-            "ImportJS: Pick js module to import for 'foo'")
+            "ImportJS: Pick JS module to import for 'foo'")
         end
 
         it 'list all possible imports' do
@@ -458,7 +458,7 @@ foo
     context 'importing a module with a package.json file' do
       let(:existing_files) { ['Foo/package.json', 'Foo/build/main.js'] }
 
-      context 'when `main` points to a js file' do
+      context 'when `main` points to a JS file' do
         let(:package_json_content) do
           {
             main: 'build/main.js'
@@ -785,7 +785,7 @@ foo
         it 'displays a message' do
           subject
           expect(VIM.last_command_message).to start_with(
-            "ImportJS: No js module to import for variable `#{word}`")
+            "ImportJS: No JS module to import for variable `#{word}`")
         end
       end
 


### PR DESCRIPTION
This prevents us from having to escape all of the double quotes, which
makes this line a bit easier to read and work with.