### PR TITLE
Add basic Emacs support

### DIFF
--- a/EMACS.md
+++ b/EMACS.md
@@ -1,0 +1,24 @@
+# Running import-js in Emacs
+
+1. Install import-js
+  * `gem install import-js`
+2. Configure import-js
+  * See [Configuration](README.md#configuration)
+2. Install import-js.el for Emacs
+  * This is not yet available on elpa/melpa, so for now this means dropping
+    import-js.el somewhere in your .emacs.d
+3. Configure your project root
+  * `(setq import-js-project-root "/path/to/project")`
+4. Start the import js project
+  * `(M-x) run-import-js`
+5. Import a file!
+  * You can use something like `(M-x) import-js-import` with your cursor over
+    the desired module
+  * It will be helpful to bind `import-js-import` to an easy-to-use binding,
+    such as:
+
+    ```
+    (define-prefix-command 'my-keymap)
+    (global-set-key (kbd "s-a") 'my-keymap)
+    (define-key my-keymap (kbd "a u") 'import-js-import)
+    ```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ file.
 
 ![Demo of import-js in action](https://raw.github.com/trotzig/import-js/master/import-js-demo.gif)
 
+[Using with Emacs](EMACS.md)
+
 ## Importing: Example
 
 Let's say that you have a project with the following setup:

--- a/lib/import_js.rb
+++ b/lib/import_js.rb
@@ -7,5 +7,6 @@ end
 require_relative 'import_js/js_module'
 require_relative 'import_js/importer'
 require_relative 'import_js/vim_editor'
+require_relative 'import_js/emacs_editor'
 require_relative 'import_js/command_line_editor'
 require_relative 'import_js/configuration'

--- a/lib/import_js/emacs_editor.rb
+++ b/lib/import_js/emacs_editor.rb
@@ -1,0 +1,145 @@
+# encoding: utf-8
+module ImportJS
+end
+
+class ImportJS::EmacsEditor
+  attr_accessor :current_word
+
+  def initialize
+    loop do
+      input = gets.chomp
+      command, value, path = input.split(':')
+
+      begin
+        @path = path
+        @file = File.readlines(path).map(&:chomp)
+
+        case command
+        when 'import'
+          @current_word = value
+          ImportJS::Importer.new(self).import
+          write_file
+          puts 'import:success'
+        when 'goto'
+          ImportJS::Importer.new(self).goto
+        end
+      rescue Exception => e
+        puts e.inspect
+      end
+    end
+  end
+
+  def write_file
+    new_file = File.open(@path, 'w')
+    @file.each {|line| new_file.puts(line) }
+    new_file.close
+  end
+
+  # Open a file specified by a path.
+  #
+  # @param file_path [String]
+  def open_file(file_path)
+    puts file_path
+  end
+
+  # Display a message to the user.
+  #
+  # @param str [String]
+  def message(str)
+    puts str
+  end
+
+  # Read the entire file into a string.
+  #
+  # @return [String]
+  def current_file_content
+    @file.join('\n')
+  end
+
+  # Reads a line from the file.
+  #
+  # Lines are one-indexed, so 1 means the first line in the file.
+  # @return [String]
+  def read_line(line_number)
+    @file[line_number - 1]
+  end
+
+  # Get the cursor position.
+  #
+  # @return [Array(Number, Number)]
+  def cursor
+    return 0, 0
+  end
+
+  # Place the cursor at a specified position.
+  #
+  # @param position_tuple [Array(Number, Number)] the row and column to place
+  #   the cursor at.
+  def cursor=(position_tuple)
+  end
+
+  # Delete a line.
+  #
+  # @param line_number [Number] One-indexed line number.
+  #   1 is the first line in the file.
+  def delete_line(line_number)
+    @file.delete_at(line_number - 1)
+  end
+
+  # Append a line right after the specified line.
+  #
+  # Lines are one-indexed, but you need to support appending to line 0 (add
+  # content at top of file).
+  # @param line_number [Number]
+  def append_line(line_number, str)
+    @file.insert(line_number, str)
+  end
+
+  # Count the number of lines in the file.
+  #
+  # @return [Number] the number of lines in the file
+  def count_lines
+    @file.size
+  end
+
+  # Ask the user to select something from a list of alternatives.
+  #
+  # @param heading [String] A heading text
+  # @param alternatives [Array<String>] A list of alternatives
+  # @return [Number, nil] the index of the selected alternative, or nil if
+  #   nothing was selected.
+  def ask_for_selection(heading, alternatives)
+    puts "asking for selection"
+    puts heading
+    puts JSON.pretty_generate(alternatives)
+    return
+
+    # need to implement this
+    escaped_list = [heading]
+    escaped_list << alternatives.each_with_index.map do |alternative, i|
+      "\"#{i + 1}: #{alternative}\""
+    end
+    escaped_list_string = '[' + escaped_list.join(',') + ']'
+
+    selected_index = VIM.evaluate("inputlist(#{escaped_list_string})")
+    return if selected_index < 1
+    selected_index - 1
+  end
+
+  # Get the preferred max length of a line
+  # @return [Number?]
+  def max_line_length
+    80
+  end
+
+  # @return [String] shiftwidth number of spaces if expandtab is not set,
+  #   otherwise `\t`
+  def tab
+    return ' ' * shift_width || 2
+  end
+
+  # @return [Number?]
+  def shift_width
+    2
+  end
+end

--- a/plugin/import-js.el
+++ b/plugin/import-js.el
@@ -1,0 +1,55 @@
+(require 'comint)
+
+(defvar import-js-buffer nil "Current import-js process buffer")
+(defvar import-js-project-root "." "Root of your project")
+(defvar import-buffer nil "The current buffer under operation")
+
+(defun import-js-send-input (command word path)
+  (comint-send-string import-js-buffer
+                      (concat command ":" word ":" path "\n")))
+
+(defun import-js-word-at-point ()
+  (save-excursion
+    (skip-chars-backward "A-Za-z0-9:_")
+    (let ((beg (point)) module)
+      (skip-chars-forward "A-Za-z0-9:_")
+      (setq module (buffer-substring beg (point)))
+      module)))
+
+(defun import-js-import ()
+  (interactive)
+  (save-some-buffers)
+  (setq import-buffer (current-buffer))
+  (import-js-send-input "import" (import-js-word-at-point) buffer-file-name))
+
+(defun import-js-goto ()
+  (interactive)
+  (import-js-send-input "goto" (import-js-word-at-point) buffer-file-name))
+
+(defun import-js-output-filter (output)
+  "Check if the current prompt is a top-level prompt."
+  (if (string-match "import:success" output)
+      (progn
+        (set-buffer import-buffer)
+        (revert-buffer t t t))))
+
+(defun run-import-js ()
+  "Open a process buffer to run import-js"
+  (interactive)
+
+  (setq command
+        (concat "ruby -e \"require 'import_js';Dir.chdir('"
+                import-js-project-root "');ImportJS::EmacsEditor.new\""))
+  (setq name "import-js")
+
+  (if (not (comint-check-proc import-js-buffer))
+      (let ((commandlist (split-string-and-unquote command))
+            (buffer (current-buffer))
+            (process-environment process-environment))
+        (setenv "PAGER" (executable-find "cat"))
+        (set-buffer (apply 'make-comint name (car commandlist)
+                           nil (cdr commandlist)))))
+  (setq import-js-buffer (format "*%s*" name))
+  (add-hook 'comint-output-filter-functions 'import-js-output-filter nil t))
+
+(provide 'import-js)


### PR DESCRIPTION
This has a long way to go to become a full featured setup for import-js,
but it is functional.

Adds two pieces:
1. ImportJS::EmacsEditor class that uses the ImportJS APIs to resolve
modules and add `require` lines.
2. An elisp plugin to start up and talk to a Ruby process that runs the
ImportJS::EmacsEditor.

For now, this works a little differently from the Vim plugin. We don't
have direct access to the Ruby code in our buffers; instead, we
communicate with the process using stdin/stdout, and leave the file
handling to Ruby.

I think there's some additional optimizations to be made by further
breaking out the core import functionality from the original Vim plugin,
and also implementing the 'experimental' goto interface.

I'd love some help/thoughts on what specs should be included.