### PR TITLE
Replace `keep_file_extensions` bool with `strip_file_extensions` array

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,19 +169,20 @@ Configure a path to a `jshint` compatible command, e.g. `jsxhint` or `eslint`.
 "jshint_cmd": "jsxhint"
 ```
 
-### `keep_file_extensions`
+### `strip_file_extensions`
 
-Set to true to make import-js keep the file extension of the imported JS file.
-E.g. `const Foo = require('foo.js')`.
+An array that controls what file extensions are stripped out from the resulting
+`require` statement. The default configuration strips out `[".js", ".jsx"]`.
+Set to an empty array `[]` to avoid stripping out extensions.
 
 ```json
-"keep_file_extensions": true
+"strip_file_extensions": [".web.js", ".js"]
 ```
 
 ## Contributing
 
 See the
 [CONTRIBUTING.md](https://github.com/trotzig/import-js/blob/master/CONTRIBUTING.md)
-file for tips on how to run, test and develop import-js locally.
+document for tips on how to run, test and develop import-js locally.
 
 Happy hacking!

--- a/lib/import_js/configuration.rb
+++ b/lib/import_js/configuration.rb
@@ -10,6 +10,7 @@ module ImportJS
     'excludes' => [],
     'jshint_cmd' => 'jshint',
     'lookup_paths' => ['.'],
+    'strip_file_extensions' => ['.js', '.jsx']
   }
 
   # Class that initializes configuration from a .importjs.json file
@@ -33,14 +34,14 @@ module ImportJS
       return resolve_destructured_alias(variable_name) unless path
 
       path = path['path'] if path.is_a? Hash
-      ImportJS::JSModule.new(nil, path, self)
+      ImportJS::JSModule.new(nil, path, [])
     end
 
     def resolve_destructured_alias(variable_name)
       @config['aliases'].each do |_, path|
         next if path.is_a? String
         if (path['destructure'] || []).include?(variable_name)
-          js_module = ImportJS::JSModule.new(nil, path['path'], self)
+          js_module = ImportJS::JSModule.new(nil, path['path'], [])
           js_module.is_destructured = true
           return js_module
         end

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -210,7 +210,8 @@ module ImportJS
             next if @config.get('excludes').any? do |glob_pattern|
               File.fnmatch(glob_pattern, f)
             end
-            js_module = ImportJS::JSModule.new(lookup_path, f, @config)
+            js_module = ImportJS::JSModule.new(
+              lookup_path, f, @config.get('strip_file_extensions'))
             next if js_module.skip
             js_module
           end.compact
@@ -221,7 +222,7 @@ module ImportJS
       @config.package_dependencies.each do |dep|
         next unless dep =~ /^#{formatted_to_regex(variable_name)}$/
         js_module = ImportJS::JSModule.new(
-          'node_modules', "node_modules/#{dep}/package.json", @config)
+          'node_modules', "node_modules/#{dep}/package.json", [])
         next if js_module.skip
         matched_modules << js_module
       end

--- a/lib/import_js/js_module.rb
+++ b/lib/import_js/js_module.rb
@@ -11,8 +11,9 @@ module ImportJS
     # @param lookup_path [String] the lookup path in which this module was found
     # @param relative_file_path [String] a full path to the file, relative to
     #   the project root.
-    # @param configuration [ImportJS::Configuration]
-    def initialize(lookup_path, relative_file_path, configuration)
+    # @param strip_file_extensions [Array] a list of file extensions to strip,
+    #   e.g. ['.js', '.jsx']
+    def initialize(lookup_path, relative_file_path, strip_file_extensions)
       @lookup_path = lookup_path
       @file_path = relative_file_path
       if relative_file_path.end_with? '/package.json'
@@ -26,8 +27,11 @@ module ImportJS
         @import_path = match[1]
       else
         @import_path = relative_file_path
-        unless configuration.get('keep_file_extensions')
-          @import_path = @import_path.sub(/\.js.*$/, '')
+        strip_file_extensions.each do |ext|
+          if @import_path.end_with?(ext)
+            @import_path = @import_path[0...-ext.length]
+            break
+          end
         end
       end
 

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -143,7 +143,7 @@ describe 'Importer' do
     end
 
     context 'with a variable name that will resolve' do
-      let(:existing_files) { ['bar/foo.js.jsx'] }
+      let(:existing_files) { ['bar/foo.jsx'] }
 
       it 'adds an import to the top of the buffer' do
         expect(subject).to eq(<<-EOS.strip)
@@ -171,7 +171,7 @@ foo
       end
 
       context 'when the variable resolves to a node.js conventional module' do
-        let(:existing_files) { ['Foo/index.js.jsx'] }
+        let(:existing_files) { ['Foo/index.jsx'] }
 
         it 'adds an import to the top of the buffer' do
           expect(subject).to eq(<<-EOS.strip)
@@ -183,11 +183,11 @@ foo
 
         it 'displays a message about the imported module' do
           expect(VIM.last_command_message).to start_with(
-            'ImportJS: Imported `Foo (main: index.js.jsx)`')
+            'ImportJS: Imported `Foo (main: index.jsx)`')
         end
 
         context 'when that module has a dot in its name' do
-          let(:existing_files) { ['Foo.io/index.js.jsx'] }
+          let(:existing_files) { ['Foo.io/index.jsx'] }
           let(:word) { 'FooIO' }
           let(:text) { 'FooIO' }
 
@@ -341,7 +341,7 @@ foo
       context 'when multiple files resolve the variable' do
         let(:existing_files) do
           [
-            'bar/foo.js.jsx',
+            'bar/foo.jsx',
             'zoo/foo.js',
             'zoo/goo/Foo/index.js'
           ]
@@ -538,7 +538,7 @@ foo
             .and_return(40)
         end
 
-        let(:existing_files) { ['fiz/bar/biz/baz/fiz/buz/boz/foo.js.jsx'] }
+        let(:existing_files) { ['fiz/bar/biz/baz/fiz/buz/boz/foo.jsx'] }
 
         context 'when expandtab is not set' do
           before(:each) do
@@ -606,7 +606,7 @@ foo
             .to receive(:max_line_length).and_return(80)
         end
 
-        let(:existing_files) { ['bar/foo.js.jsx'] }
+        let(:existing_files) { ['bar/foo.jsx'] }
 
         it 'does not wrap them' do
           expect(subject).to eq(<<-EOS.strip)
@@ -751,11 +751,11 @@ memoize
         end
       end
 
-      context 'when keep_file_extensions is true' do
+      context 'when strip_file_extensions is empty' do
         let(:existing_files) { ['bar/foo.js'] }
         let(:configuration) do
           {
-            'keep_file_extensions' => true
+            'strip_file_extensions' => []
           }
         end
 
@@ -802,7 +802,7 @@ foo
         end
 
         context 'with a variable name that will resolve' do
-          let(:existing_files) { ['bar/foo.js.jsx'] }
+          let(:existing_files) { ['bar/foo.jsx'] }
 
           it 'adds an import to the top of the buffer using the declaration_keyword' do
             expect(subject).to eq(<<-EOS.strip)
@@ -895,7 +895,7 @@ foo
     end
 
     context 'when one undefined variable exists' do
-      let(:existing_files) { ['bar/foo.js.jsx'] }
+      let(:existing_files) { ['bar/foo.jsx'] }
       let(:jshint_result) do
         "stdin: line 3, col 11, 'foo' is not defined."
       end
@@ -939,7 +939,7 @@ foo
     end
 
     context 'when multiple undefined variables exist' do
-      let(:existing_files) { ['bar/foo.js.jsx', 'bar.js'] }
+      let(:existing_files) { ['bar/foo.jsx', 'bar.js'] }
       let(:text) { 'var a = foo + bar;' }
 
       let(:jshint_result) do
@@ -958,7 +958,7 @@ var a = foo + bar;
     end
 
     context 'when the list of undefined variables has duplicates' do
-      let(:existing_files) { ['bar/foo.js.jsx', 'bar.js'] }
+      let(:existing_files) { ['bar/foo.jsx', 'bar.js'] }
       let(:text) { 'var a = foo + bar;' }
 
       let(:jshint_result) do

--- a/spec/import_js/js_module_spec.rb
+++ b/spec/import_js/js_module_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe 'JSModule' do
+  let(:lookup_path) { 'app' }
+  let(:relative_file_path) { 'app/lib/foo.js' }
+
+  subject do
+    ImportJS::JSModule.new(
+      lookup_path,
+      relative_file_path,
+      strip_file_extensions
+    )
+  end
+
+  describe '.import_path' do
+    context 'with an empty `strip_file_extensions` config' do
+      let(:strip_file_extensions) { [] }
+
+      it 'strips out the lookup path from relative_file_path' do
+        expect(subject.import_path).to start_with('lib/')
+      end
+
+      it 'does not strip file extension' do
+        expect(subject.import_path).to eq('lib/foo.js')
+      end
+    end
+
+    context 'when the file extension is not in `strip_file_extensions`' do
+      let(:strip_file_extensions) { ['.jsx'] }
+
+      it 'does not strip file extension' do
+        expect(subject.import_path).to eq('lib/foo.js')
+      end
+    end
+
+    context 'when the file extension is in `strip_file_extensions`' do
+      let(:strip_file_extensions) { ['.js', '.jsx'] }
+
+      it 'strips the file extension' do
+        expect(subject.import_path).to eq('lib/foo')
+      end
+    end
+
+    context 'with a double extension in `strip_file_extensions`' do
+      let(:strip_file_extensions) { ['.web.js'] }
+
+      context 'and the module does not have that extension' do
+        it 'does not strip the file extension' do
+          expect(subject.import_path).to eq('lib/foo.js')
+        end
+      end
+
+      context 'and the module has that extension' do
+        let(:relative_file_path) { 'lib/foo.web.js' }
+
+        it 'strips the file extension' do
+          expect(subject.import_path).to eq('lib/foo')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In order to get better control over what the resulting `require`
statement ends up as, we need more fine-grained control over what file
extensions are stripped out. I recently ran into a problem importing a
`.json` file because or config was set to strip out all file extensions.

The old configuration option was

  "keep_file_extensions": false

The new option is

  "strip_file_extensions": ['.jsx', '.js']

The dot (.) is required, and I choose to include it because that's what
webpack is doing [1]. (Thanks to @lencioni for linking me there.)

While I was in specs, I decided to rename a few .js.jsx extensions so
that we could make use of the default configuration for
`strip_file_extensions`.

Fixes #62

[1]: https://github.com/webpack/docs/wiki/configuration#resolveextensions