### PR TITLE
Fix a couple of small bugs when deduping

### DIFF
--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -103,7 +103,9 @@ module ImportJS
         (.+?)                # \1 variable assignment
         \s*=\s*
         require\(
-          ('.*')             # \2 module path
+          ('|")              # \2 opening quote
+          ([^\2]+)           # \3 module path
+          \2                 # closing quote
         \);?
         \s*
       }xm
@@ -111,15 +113,17 @@ module ImportJS
       import_regex = %r{
         \A
         import\s+
-        (.*?)       # \1 variable assignment
+        (.*?)              # \1 variable assignment
         \s+from\s+
-        ('.*')      # \2 module path
+        ('|")              # \2 opening quote
+        ([^\2]+)           # \3 module path
+        \2                 # closing quote
         ;?\s*
       }xm
 
       import
-        .sub(const_let_var_regex, '\1\2')
-        .sub(import_regex, '\1\2')
+        .sub(const_let_var_regex, '\1 \3')
+        .sub(import_regex, '\1 \3')
     end
 
     # @param variable_name [String]

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -93,6 +93,35 @@ module ImportJS
       write_imports(variable_name, resolved_js_module)
     end
 
+    # Helper for determining uniqueness.
+    # @param import [String]
+    # @return [String]
+    def normalize_import(import)
+      const_let_var_regex = %r{
+        \A
+        (?:const|let|var)\s+ # declaration keyword
+        (.+?)                # \1 variable assignment
+        \s*=\s*
+        require\(
+          ('.*')             # \2 module path
+        \);?
+        \s*
+      }xm
+
+      import_regex = %r{
+        \A
+        import\s+
+        (.*?)       # \1 variable assignment
+        \s+from\s+
+        ('.*')      # \2 module path
+        ;?\s*
+      }xm
+
+      import
+        .sub(const_let_var_regex, '\1\2')
+        .sub(import_regex, '\1\2')
+    end
+
     # @param variable_name [String]
     # @param js_module [ImportJS::JSModule]
     def write_imports(variable_name, js_module)
@@ -113,14 +142,7 @@ module ImportJS
 
       # Sort the block of imports
       modified_imports.sort!.uniq! do |import|
-        # Determine uniqueness by discarding the declaration keyword (`const`,
-        # `let`, `var`, or `import`), "=" or "from", and normalizing multiple
-        # whitespace chars to single spaces.
-        import
-          .sub(/\A(const|let|var|import)\s+/, '')
-          .sub(/(from|=\s+require)/m, '')
-          .sub(/\(?('.*')\)?/m, '\1')
-          .sub(/\s\s+/s, ' ')
+        normalize_import(import)
       end
 
       # Delete old imports, then add the modified list back in.

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -996,6 +996,22 @@ foo
             end
           end
 
+          context 'when that variable is already imported using `var` and double quotes' do
+            let(:text) { <<-EOS.strip }
+var foo = require("bar/foo");
+
+foo
+            EOS
+
+            it 'changes the `var` to declaration_keyword and doubles to singles' do
+              expect(subject).to eq(<<-EOS.strip)
+import foo from 'bar/foo';
+
+foo
+              EOS
+            end
+          end
+
           context 'when that variable is already imported and has "from" in it' do
             let(:text) { <<-EOS.strip }
 var fromfoo = require('bar/fromfoo');

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -970,7 +970,7 @@ foo
         end
 
         context 'with a variable name that will resolve' do
-          let(:existing_files) { ['bar/foo.jsx'] }
+          let(:existing_files) { ['bar/foo.jsx', 'bar/fromfoo.jsx'] }
 
           it 'adds an import to the top of the buffer' do
             expect(subject).to eq(<<-EOS.strip)
@@ -992,6 +992,23 @@ foo
 import foo from 'bar/foo';
 
 foo
+              EOS
+            end
+          end
+
+          context 'when that variable is already imported and has "from" in it' do
+            let(:text) { <<-EOS.strip }
+var fromfoo = require('bar/fromfoo');
+
+fromfoo
+            EOS
+            let(:word) { 'fromfoo' }
+
+            it 'changes the `var` to declaration_keyword' do
+              expect(subject).to eq(<<-EOS.strip)
+import fromfoo from 'bar/fromfoo';
+
+fromfoo
               EOS
             end
           end


### PR DESCRIPTION
I noticed a couple of small bugs in the deduping code.

1. If the module contained "from" in the name, the deduping could break.
2. If the import was using double quotes, the deduping could break.

This PR has commits that fix both of these problems, each with a test that failed before the fix.