### PR TITLE
Correctly save current buffer before reverting and add goto

### DIFF
--- a/EMACS.md
+++ b/EMACS.md
@@ -22,3 +22,8 @@
     (global-set-key (kbd "s-a") 'my-keymap)
     (define-key my-keymap (kbd "a u") 'import-js-import)
     ```
+6. (Experimental) Go directly to a file
+  * The experimental import-js goto interface allows us to jump to a package
+  * `(M-x) import-js-goto` will jump to the appropriate file found by import-js
+  * This should also be bound to something useful:
+    `(global-set-key (kbd "<f4>") 'import-js-goto)`

--- a/lib/import_js/emacs_editor.rb
+++ b/lib/import_js/emacs_editor.rb
@@ -13,10 +13,10 @@ class ImportJS::EmacsEditor
       begin
         @path = path
         @file = File.readlines(path).map(&:chomp)
+        @current_word = value
 
         case command
         when 'import'
-          @current_word = value
           ImportJS::Importer.new(self).import
           write_file
           puts 'import:success'
@@ -39,7 +39,7 @@ class ImportJS::EmacsEditor
   #
   # @param file_path [String]
   def open_file(file_path)
-    puts file_path
+    puts "goto:success:#{File.expand_path(file_path)}"
   end
 
   # Display a message to the user.

--- a/plugin/import-js.el
+++ b/plugin/import-js.el
@@ -33,7 +33,11 @@
         (let ((old-buffer (current-buffer)))
           (save-current-buffer
             (set-buffer import-buffer)
-            (revert-buffer t t t))))))
+            (revert-buffer t t t)))))
+  (if (string-match "goto:success:\\(.*\\)" output)
+      (let ((old-buffer (current-buffer)))
+        (save-current-buffer
+          (find-file (match-string 1 output))))))
 
 (defun run-import-js ()
   "Open a process buffer to run import-js"

--- a/plugin/import-js.el
+++ b/plugin/import-js.el
@@ -30,8 +30,10 @@
   "Check if the current prompt is a top-level prompt."
   (if (string-match "import:success" output)
       (progn
-        (set-buffer import-buffer)
-        (revert-buffer t t t))))
+        (let ((old-buffer (current-buffer)))
+          (save-current-buffer
+            (set-buffer import-buffer)
+            (revert-buffer t t t))))))
 
 (defun run-import-js ()
   "Open a process buffer to run import-js"


### PR DESCRIPTION
Since we are switching the buffer context in order to revert, we need to
properly handle switching back so other functions operate normally.

This clears the 'error in process filter: Wrong type argument: processp, nil'
error we were seeing in:

https://github.com/trotzig/import-js/pull/61

Also, implements goto:

Make goto work with Emacs

While experimental and not necessarily bound to import-js, implementing
goto using the same underlying package finding logic is very simple and
extremely useful.
    
Implement the 'goto' functionality with Emacs, so you can easily
navigate to packages with a simple keystroke.
