### PR TITLE
Add ability to use `{filename}` in aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,23 @@ const { memoize } = require('underscore');
 memoize(() => { foo() });
 ```
 
+Aliases can be made dynamic by using the `{filename}` string. This part of the
+alias will be replaced by the name of the file you are currently editing.
+
+e.g.
+
+```json
+"aliases": {
+  "styles": "./{filename}.scss"
+}
+```
+
+will for a file `foo/bar.js` result in
+
+```javascript
+const styles = require('./bar.scss');
+```
+
 ### `declaration_keyword`
 
 If you are using ES6 (ES 2015), you have access to `let`, `const`, and `import`

--- a/lib/import_js/configuration.rb
+++ b/lib/import_js/configuration.rb
@@ -28,11 +28,19 @@ module ImportJS
       @config[key]
     end
 
-    def resolve_alias(variable_name)
+    # @param variable_name [String]
+    # @param path_to_current_file [String?]
+    # @return [ImportJS::JSModule?]
+    def resolve_alias(variable_name, path_to_current_file)
       path = @config['aliases'][variable_name]
       return resolve_destructured_alias(variable_name) unless path
 
       path = path['path'] if path.is_a? Hash
+
+      if path_to_current_file && !path_to_current_file.empty?
+        path = path.sub(/\{filename\}/,
+                        File.basename(path_to_current_file, '.*'))
+      end
       ImportJS::JSModule.new(nil, path, [])
     end
 

--- a/lib/import_js/emacs_editor.rb
+++ b/lib/import_js/emacs_editor.rb
@@ -42,6 +42,15 @@ class ImportJS::EmacsEditor
     puts "goto:success:#{File.expand_path(file_path)}"
   end
 
+  # Get the path to the file currently being edited. May return `nil` if an
+  # anonymous file is being edited.
+  #
+  # @return [String?]
+  def path_to_current_file
+    # Not yet implemented for Emacs
+    nil
+  end
+
   # Display a message to the user.
   #
   # @param str [String]

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -220,7 +220,8 @@ module ImportJS
     # @param variable_name [String]
     # @return [Array]
     def find_js_modules(variable_name)
-      if alias_module = @config.resolve_alias(variable_name)
+      if alias_module = @config.resolve_alias(variable_name,
+                                              @editor.path_to_current_file)
         return [alias_module]
       end
 

--- a/lib/import_js/vim_editor.rb
+++ b/lib/import_js/vim_editor.rb
@@ -10,6 +10,14 @@ module ImportJS
       VIM.evaluate("expand('<cword>')")
     end
 
+    # Get the path to the file currently being edited. May return `nil` if an
+    # anonymous file is being edited.
+    #
+    # @return [String?]
+    def path_to_current_file
+      VIM.evaluate("expand('%')")
+    end
+
     # Open a file specified by a path.
     #
     # @param file_path [String]


### PR DESCRIPTION
By using {filename} in an alias, you can use the name of the currently
edited file in the resulting import statement. @lencioni suggested
looking at vim-projectionist [1] for inspiration. Which I did, but I
decided to not use much of it. The main reason being that projecting is
a different usecase, where you have configuration that apply on a large
set of files. We want to apply a configuration on a single alias.

To keep it simple, I only added the filename (without file extension) to
begin with. I can imagine usecases where you need more than just that
though (e.g. a relative path within the project, or a relative path from
a `lookup_path`). We can extend this functionality when those usecases
pop up.

[Fixes #76]

[1]: https://github.com/tpope/vim-projectionist