### PR TITLE
Update Emacs instructions to use MELPA

### DIFF
--- a/EMACS.md
+++ b/EMACS.md
@@ -5,8 +5,9 @@
 2. Configure import-js
   * See [Configuration](README.md#configuration)
 2. Install import-js.el for Emacs
-  * This is not yet available on elpa/melpa, so for now this means dropping
-    import-js.el somewhere in your .emacs.d
+  * Install via [MELPA](https://melpa.org/#/import-js)
+  * Alternatively, Copy plugins/import-js.el into your Emacs load-path and add
+    `(require 'import-js)` to your config
 3. Configure your project root
   * `(setq import-js-project-root "/path/to/project")`
 4. Start the import js project

--- a/plugin/import-js.el
+++ b/plugin/import-js.el
@@ -73,7 +73,8 @@
   "Open a process buffer to run import-js"
   (interactive)
   (let ((command (concat "ruby -e \"require 'import_js';Dir.chdir('"
-                         import-js-project-root "');ImportJS::EmacsEditor.new\""))
+                         (shell-quote-argument import-js-project-root)
+                         "');ImportJS::EmacsEditor.new\""))
         (name "import-js"))
     (if (not (comint-check-proc import-js-buffer))
         (let ((commandlist (split-string-and-unquote command))


### PR DESCRIPTION
Allows users to use a package manager to install import-js. Also, fix some escaping.