### PR TITLE
Add fix_imports API to Emacs plugin

### DIFF
--- a/EMACS.md
+++ b/EMACS.md
@@ -23,8 +23,18 @@
     (global-set-key (kbd "s-a") 'my-keymap)
     (define-key my-keymap (kbd "a u") 'import-js-import)
     ```
-6. (Experimental) Go directly to a file
-  * The experimental import-js goto interface allows us to jump to a package
+6. Go directly to a file
+  * The import-js goto interface allows us to jump to a package
   * `(M-x) import-js-goto` will jump to the appropriate file found by import-js
   * This should also be bound to something useful:
     `(global-set-key (kbd "<f4>") 'import-js-goto)`
+7. Fix your imports
+  * Optionally, you can configure import-js to fix your imports for you, adding
+    unknown variables and removing unused imports. import-js uses eslint to find
+    these variables.
+  * `eslint` must be in your PATH.
+  * eslint plugins must be installed for that specific version of eslint (if
+    eslint is a global eslint, you may need to install the plugins globally)
+  * Run with `(M-x) import-js-fix`
+  * You can also configure `import-js-fix` to run on save:
+    `(add-hook 'after-save-hook 'import-js-fix)`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ and hit `<leader>j` (Vim), or `(M-x) import-js-import` (Emacs), or select
 import-js comes with plugins for the following editors:
 
 - [Emacs](EMACS.md) (Thanks to
-  [@kevin.kehl](https://github.com/kevin.kehl)!)
+  [@kevinkehl](https://github.com/kevinkehl)!)
 - [Vim](VIM.md)
 - [Sublime](Sublime.md) (Thanks to
   [@janpaul123](https://github.com/janpaul123))

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and hit `<leader>j` (Vim), or `(M-x) import-js-import` (Emacs), or select
 
 import-js comes with plugins for the following editors:
 
-- [Emacs (experimental)](EMACS.md) (Thanks to
+- [Emacs](EMACS.md) (Thanks to
   [@kevin.kehl](https://github.com/kevin.kehl)!)
 - [Vim](VIM.md)
 - [Sublime](Sublime.md) (Thanks to

--- a/lib/import_js/emacs_editor.rb
+++ b/lib/import_js/emacs_editor.rb
@@ -22,6 +22,12 @@ class ImportJS::EmacsEditor
           puts 'import:success'
         when 'goto'
           ImportJS::Importer.new(self).goto
+        when 'fix'
+          ImportJS::Importer.new(self).fix_imports
+          write_file
+          puts 'import:success'
+        else
+          puts "unknown command: #{command}"
         end
       rescue Exception => e
         puts e.inspect
@@ -61,7 +67,7 @@ class ImportJS::EmacsEditor
   #
   # @return [String]
   def current_file_content
-    @file.join('\n')
+    @file.join("\n")
   end
 
   # Reads a line from the file.

--- a/plugin/import-js.el
+++ b/plugin/import-js.el
@@ -54,6 +54,13 @@
   (import-js-send-input "import" (import-js-word-at-point) buffer-file-name))
 
 ;;;###autoload
+(defun import-js-fix ()
+  (interactive)
+  (save-some-buffers)
+  (setq import-buffer (current-buffer))
+  (import-js-send-input "fix" "*" buffer-file-name))
+
+;;;###autoload
 (defun import-js-goto ()
   (interactive)
   (import-js-send-input "goto" (import-js-word-at-point) buffer-file-name))


### PR DESCRIPTION
Allow users to use the 'fix_imports' function that automatically adds
unimported variables and removes unused imports. Fix a literal '\n' to
get file contents.

Add instructions on setup. The setup can be a little dicey and is
dependent on your eslint config, which I think is a bit dangerous, so
calling it 'optional'.

Remove references to 'experimental' for Emacs (its not really
experimental anymore =D).
