### PR TITLE
Use eslint unix format instead of compact format

### DIFF
--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -105,14 +105,14 @@ module ImportJS
       command = %w[
         eslint
         --stdin
-        --format compact
+        --format unix
         --rule 'no-undef: 2'
         --rule 'no-unused-vars: [2, { "vars": "all", "args": "none" }]'
       ].join(' ')
       out, err = Open3.capture3(command,
                                 stdin_data: @editor.current_file_content)
 
-      if out =~ /Error - Parsing error: / ||
+      if out =~ /Parsing error: / ||
          out =~ /Unrecoverable syntax error/
         fail ImportJS::ParseError.new, out
       end

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -1230,7 +1230,7 @@ foo
     context 'when one undefined variable exists' do
       let(:existing_files) { ['bar/foo.jsx'] }
       let(:eslint_result) do
-        "stdin: line 3, col 11, \"foo\" is not defined."
+        "stdin:3:11: \"foo\" is not defined. [Error/no-undef]"
       end
 
       it 'imports that variable' do
@@ -1245,7 +1245,7 @@ foo
         # Undefined jsx variables are wrapped in single quotes
 
         let(:eslint_result) do
-          "stdin: line 3, col 11, 'foo' is not defined."
+          "stdin:3:11: 'foo' is not defined. [Error/no-undef]"
         end
 
         it 'imports that variable' do
@@ -1259,8 +1259,8 @@ foo
 
       context 'when eslint returns other issues' do
         let(:eslint_result) do
-          "stdin: line 1, col 1, Use the function form of \"use strict\".\n" \
-          "stdin: line 3, col 11, \"foo\" is not defined."
+          "stdin:1:1: Use the function form of \"use strict\". [Error/strict]\n" \
+          "stdin:3:11: \"foo\" is not defined. [Error/no-undef]"
         end
 
         it 'still imports the variable' do
@@ -1278,8 +1278,8 @@ foo
       let(:text) { 'var a = foo + bar;' }
 
       let(:eslint_result) do
-        "stdin: line 3, col 11, \"foo\" is not defined.\n" \
-        "stdin: line 3, col 11, \"bar\" is not defined."
+        "stdin:3:11: \"foo\" is not defined. [Error/no-undef]\n" \
+        "stdin:3:11: \"bar\" is not defined. [Error/no-undef]"
       end
 
       it 'imports all variables' do
@@ -1297,10 +1297,10 @@ var a = foo + bar;
       let(:text) { 'var a = foo + bar;' }
 
       let(:eslint_result) do
-        "stdin: line 3, col 11, \"foo\" is not defined.\n" +
-        "stdin: line 3, col 11, \"foo\" is not defined.\n" +
-        "stdin: line 3, col 11, \"foo\" is not defined.\n" +
-        "stdin: line 3, col 11, \"bar\" is not defined."
+        "stdin:3:11: \"foo\" is not defined. [Error/no-undef]\n" +
+        "stdin:3:11: \"foo\" is not defined. [Error/no-undef]\n" +
+        "stdin:3:11: \"foo\" is not defined. [Error/no-undef]\n" +
+        "stdin:3:11: \"bar\" is not defined. [Error/no-undef]"
       end
 
       it 'imports all variables' do
@@ -1335,7 +1335,7 @@ var a = foo + bar;
 
     context 'when eslint can not parse' do
       let(:eslint_result) do
-        'stdin: line 1, col 1, Error - Parsing error: Unexpected token ILLEGAL'
+        'stdin:1:1: Parsing error: Unexpected token ILLEGAL [Error]'
       end
 
       it 'throws an error' do
@@ -1351,7 +1351,7 @@ var foo = require('bar/foo');
 bar
       EOS
       let(:eslint_result) do
-        "stdin: line 1, col 4, \"foo\" is defined but never used"
+        "stdin:1:4: \"foo\" is defined but never used [Error/no-unused-vars]"
       end
 
       it 'removes that import' do
@@ -1373,8 +1373,8 @@ baz
       EOS
 
       let(:eslint_result) do
-        "stdin: line 3, col 11, \"foo\" is defined but never used\n" \
-        "stdin: line 3, col 11, \"bar\" is defined but never used"
+        "stdin:3:11: \"foo\" is defined but never used [Error/no-unused-vars]\n" \
+        "stdin:3:11: \"bar\" is defined but never used [Error/no-unused-vars]"
       end
 
       it 'removes all unused imports' do
@@ -1394,7 +1394,7 @@ bar
       EOS
 
       let(:eslint_result) do
-        "stdin: line 3, col 11, \"foo\" is defined but never used\n" \
+        "stdin:3:11: \"foo\" is defined but never used [Error/no-unused-vars]\n" \
       end
 
       it 'removes that variable from the destructured list' do
@@ -1415,7 +1415,7 @@ bar
       EOS
 
       let(:eslint_result) do
-        "stdin: line 3, col 11, \"foo\" is defined but never used\n" \
+        "stdin:3:11: \"foo\" is defined but never used [Error/no-unused-vars]\n" \
       end
 
       it 'removes the whole import' do


### PR DESCRIPTION
Although these formatters produce pretty similar output, it seems that
the unix formatter is made to be machine readable whereas the compact
one may not have been designed with that goal in mind. This should help
this portion of ImportJS be more stable as things change.

There are other machine readable formatters available that I considered,
such as json, but since unix was so simple I decided to go with it.

Thanks to @michaelficarra for the nudge [0].

[0]: https://github.com/eslint/eslint/issues/4845#issuecomment-168501409