### PR TITLE
Fix parsing of new wrapping style of destructuring

### DIFF
--- a/lib/import_js/import_statement.rb
+++ b/lib/import_js/import_statement.rb
@@ -36,7 +36,7 @@ module ImportJS
         (?<destructured>.*)  # <destructured> variables
         \s*
       \}
-    }x
+    }xm
 
     attr_accessor :assignment
     attr_accessor :original_import_string # a cache of the parsed import string

--- a/spec/import_js/import_statement_spec.rb
+++ b/spec/import_js/import_statement_spec.rb
@@ -35,6 +35,18 @@ describe ImportJS::ImportStatement do
           expect(subject.destructured_variables).to eq(['foo'])
         end
 
+        context 'and it has line breaks' do
+          let(:string) { "const {\n  foo,\n  bar,\n} = require('foo');" }
+
+          it 'returns a valid ImportStatement instance' do
+            expect(subject.assignment).to eq("{\n  foo,\n  bar,\n}")
+            expect(subject.path).to eq('foo')
+            expect(subject.destructured?).to be_truthy
+            expect(subject.default_variable).to eq(nil)
+            expect(subject.destructured_variables).to eq(['foo', 'bar'])
+          end
+        end
+
         context 'injecting a new destructured variable' do
           let(:injected_variable) { 'bar' }
           let(:statement) do
@@ -98,6 +110,18 @@ describe ImportJS::ImportStatement do
           expect(subject.default_variable).to eq(nil)
           expect(subject.destructured_variables).to eq(['foo'])
         end
+
+        context 'and it has line breaks' do
+          let(:string) { "import {\n  foo,\n  bar,\n} from 'foo';" }
+
+          it 'returns a valid ImportStatement instance' do
+            expect(subject.assignment).to eq("{\n  foo,\n  bar,\n}")
+            expect(subject.path).to eq('foo')
+            expect(subject.destructured?).to be_truthy
+            expect(subject.default_variable).to eq(nil)
+            expect(subject.destructured_variables).to eq(['foo', 'bar'])
+          end
+        end
       end
 
       context 'and it has default and a destructured assignment' do
@@ -109,6 +133,18 @@ describe ImportJS::ImportStatement do
           expect(subject.destructured?).to be_truthy
           expect(subject.default_variable).to eq('foo')
           expect(subject.destructured_variables).to eq(['bar'])
+        end
+
+        context 'and it has line breaks' do
+          let(:string) { "import foo, {\n  bar,\n  baz,\n} from 'foo';" }
+
+          it 'returns a valid ImportStatement instance' do
+            expect(subject.assignment).to eq("foo, {\n  bar,\n  baz,\n}")
+            expect(subject.path).to eq('foo')
+            expect(subject.destructured?).to be_truthy
+            expect(subject.default_variable).to eq('foo')
+            expect(subject.destructured_variables).to eq(['bar', 'baz'])
+          end
         end
       end
     end


### PR DESCRIPTION
I noticed some odd behavior with the new wrapping style of destructuring
imports. Basically, it was not removing unused references from
destructured imports, it was wrapping them weirdly on subsequent runs,
and if you removed some variables from a destructured import and ran fix
on the file again, it would put them back but in a second set of
curlies.

This was all wrong because the regex used to parse these imports was not
in multiline mode. I added some specs that would have prevented this.

Fixes #110 and fixes #111.