### PR TITLE
Prevent unnecessarily dirtying the buffer when replacing imports

### DIFF
--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -170,6 +170,17 @@ module ImportJS
           @editor.tab)
       end.flatten.sort
 
+      # Find old import strings so we can compare with the new import strings
+      # and see if anything has changed.
+      old_import_strings = []
+      old_imports_lines.times do |line|
+        old_import_strings << @editor.read_line(1 + line + imports_start_at)
+      end
+
+      # If nothing has changed, bail to prevent unnecessarily dirtying the
+      # buffer.
+      return if import_strings == old_import_strings
+
       # Delete old imports, then add the modified list back in.
       old_imports_lines.times { @editor.delete_line(1 + imports_start_at) }
       import_strings.reverse_each do |import_string|


### PR DESCRIPTION
I noticed that running the fix imports command on a fresh buffer that
didn't actually need it caused the buffer to become dirty even though
nothing changed. This doesn't feel quite right to me, so I decided to
add a bit of code to avoid it.