### PR TITLE
Add eslint_executable configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ Webpack, these should match the `modulesDirectories` configuration. Example:
 *Tip:* Don't put `node_modules` here. import-js will find your Node
 dependencies through your `package.json` file.
 
+### `eslint_executable`
+
+By default, import-js will call out to the globally installed `eslint` command
+when fixing imports. If you are using ESLint in your project and have a local
+`.eslintrc` file, you may want import-js to use the locally installed `eslint`
+instead. This is especially useful if your `.eslintrc` includes dependencies on
+other `eslint-*` packages such as shared configurations, plugins, or parsers.
+
+To configure this to use the locally installed `eslint`, set the
+`eslint_executable` configuration. Example:
+
+```json
+"eslint_executable": "node_modules/.bin/eslint"
+```
+
 ### `excludes`
 
 Define a list of glob patterns that match files and directories that you don't

--- a/lib/import_js/configuration.rb
+++ b/lib/import_js/configuration.rb
@@ -7,6 +7,7 @@ module ImportJS
   DEFAULT_CONFIG = {
     'aliases' => {},
     'declaration_keyword' => 'import',
+    'eslint_executable' => 'eslint',
     'excludes' => [],
     'lookup_paths' => ['.'],
     'strip_file_extensions' => ['.js', '.jsx']

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -90,8 +90,7 @@ module ImportJS
 
     # @return [Array<String>] the output from eslint, line by line
     def run_eslint_command
-      command = %w[
-        eslint
+      command = @config.get('eslint_executable') + ' ' + %w[
         --stdin
         --format unix
         --rule 'no-undef: 2'

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -1297,6 +1297,29 @@ foo
       VIM::Buffer.current_buffer.to_s
     end
 
+    it 'calls out to global eslint' do
+      expect(Open3).to receive(:capture3).with(/\Aeslint /, any_args)
+      subject
+    end
+
+    context 'with eslint_executable configuration' do
+      let(:eslint_executable) { 'node_modules/.bin/eslint' }
+
+      before do
+        allow_any_instance_of(ImportJS::Configuration)
+          .to receive(:get).and_call_original
+        allow_any_instance_of(ImportJS::Configuration)
+          .to receive(:get).with('eslint_executable')
+          .and_return(eslint_executable)
+      end
+
+      it 'calls out to the configured eslint executable' do
+        command = Regexp.escape(eslint_executable)
+        expect(Open3).to receive(:capture3).with(/\A#{command} /, any_args)
+        subject
+      end
+    end
+
     context 'when no undefined variables exist' do
       it 'leaves the buffer unchanged' do
         expect(subject).to eq(text)


### PR DESCRIPTION
If there is a local .eslintrc file that includes dependencies on
eslint-* packages, such as configurations, plugins, or parsers, running
the globally installed eslint can fail if these packages are not also
globally installed. To make this smoother for teams, I am adding a
configuration option that allows people to configure the eslint
executable, which enables them to use the locally installed eslint,
which should be able to find the other dependencies for their project.

Fixes #115.