### PR TITLE
Add `ignore_package_prefixes` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,20 @@ relatively.
 "use_relative_paths": true
 ```
 
+### `ignore_package_prefixes`
+
+If you have package dependencies speficied in `package.json` that are prefixed
+with e.g. an organization name but want to be able to import these without the
+package prefix, you can set the `ignore_package_prefixes` configuration option.
+
+```json
+"ignore_package_prefixes": ["my-company-"]
+```
+
+When package dependencies are matched, these prefixes will be ignored. As an
+example, a variable named `validator` would match a package named
+`my-company-validator`.
+
 ## Contributing
 
 See the

--- a/lib/import_js/configuration.rb
+++ b/lib/import_js/configuration.rb
@@ -9,6 +9,7 @@ module ImportJS
     'declaration_keyword' => 'import',
     'eslint_executable' => 'eslint',
     'excludes' => [],
+    'ignore_package_prefixes' => [],
     'lookup_paths' => ['.'],
     'strip_file_extensions' => ['.js', '.jsx'],
     'use_relative_paths' => false

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -277,13 +277,19 @@ module ImportJS
 
       # Find imports from package.json
       @config.package_dependencies.each do |dep|
-        next unless dep =~ /^#{formatted_to_regex(variable_name)}$/
-        js_module = ImportJS::JSModule.new(
-          lookup_path: 'node_modules',
-          relative_file_path: "node_modules/#{dep}/package.json",
-          strip_file_extensions: [])
-        next if js_module.skip
-        matched_modules << js_module
+        ignore_prefixes = @config.get('ignore_package_prefixes')
+        dep_matcher = /^#{formatted_to_regex(variable_name)}$/
+        if dep =~ dep_matcher ||
+           ignore_prefixes.any? do |prefix|
+             dep.sub(/^#{prefix}/, '') =~ dep_matcher
+           end
+          js_module = ImportJS::JSModule.new(
+            lookup_path: 'node_modules',
+            relative_file_path: "node_modules/#{dep}/package.json",
+            strip_file_extensions: [])
+          next if js_module.skip
+          matched_modules << js_module
+        end
       end
 
       # If you have overlapping lookup paths, you might end up seeing the same


### PR DESCRIPTION
Which will cause variables to match node_modules packages even when
variable names lack the prefix.

E.g. a variable named `foo` will match `bar-foo` if
`ignore_package_prefixes` contains `"bar-"`.

[Fixes #125]