### PR TITLE
Allow pluralized file paths to match variable

### DIFF
--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -334,10 +334,17 @@ module ImportJS
     def formatted_to_regex(string)
       # Based on
       # http://stackoverflow.com/questions/1509915/converting-camel-case-to-underscore-case-in-ruby
-      string.
-        gsub(/([a-z\d])([A-Z])/, '\1.?\2'). # separates camelCase words with '.?'
-        tr('-_', '.'). # replaces underscores or dashes with '.'
-        downcase # converts all upper to lower case
+
+      # The pattern to match in between words.
+      split_pattern = 's?.?'
+
+      # Split up the string, allow pluralizing and a single (any) character
+      # in between. This will make e.g. 'fooBar' match 'foos/bar', 'foo_bar',
+      # and 'foobar'.
+      string
+        .gsub(/([a-z\d])([A-Z])/, '\1' + split_pattern + '\2') # camelCase
+        .tr('-_', split_pattern)
+        .downcase
     end
 
     # @return [String]

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -335,7 +335,16 @@ module ImportJS
       # Based on
       # http://stackoverflow.com/questions/1509915/converting-camel-case-to-underscore-case-in-ruby
 
-      # The pattern to match in between words.
+      # The pattern to match in between words. The "es" and "s" match is there
+      # to catch pluralized folder names. There is a risk that this is overly
+      # aggressive and will lead to trouble down the line. In that case, we can
+      # consider adding a configuration option to control mapping a singular
+      # variable name to a plural folder name (suggested by @lencioni in #127).
+      # E.g.
+      #
+      # {
+      #   "^mock": "./mocks/"
+      # }
       split_pattern = '(?:es|s)?.?'
 
       # Split up the string, allow pluralizing and a single (any) character

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -336,7 +336,7 @@ module ImportJS
       # http://stackoverflow.com/questions/1509915/converting-camel-case-to-underscore-case-in-ruby
 
       # The pattern to match in between words.
-      split_pattern = 's?.?'
+      split_pattern = '(?:es|s)?.?'
 
       # Split up the string, allow pluralizing and a single (any) character
       # in between. This will make e.g. 'fooBar' match 'foos/bar', 'foo_bar',

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -345,7 +345,7 @@ module ImportJS
       # {
       #   "^mock": "./mocks/"
       # }
-      split_pattern = '(?:es|s)?.?'
+      split_pattern = '(es|s)?.?'
 
       # Split up the string, allow pluralizing and a single (any) character
       # in between. This will make e.g. 'fooBar' match 'foos/bar', 'foo_bar',

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -211,6 +211,19 @@ import barFoo from 'sko/bars/foo';
 barFoo
               EOS
             end
+
+            context 'when the variable also has "s" at the end' do
+              let(:word) { 'barsFoo' }
+              let(:text) { 'barsFoo' }
+
+              it 'resolves the import' do
+                expect(subject).to eq(<<-EOS.strip)
+import barsFoo from 'sko/bars/foo';
+
+barsFoo
+                EOS
+              end
+            end
           end
         end
 
@@ -236,6 +249,19 @@ import BarFooTa from 'sko/bars/foos/ta';
 
 BarFooTa
               EOS
+            end
+
+            context 'when the variable also has "s"' do
+              let(:word) { 'BarsFoosTa' }
+              let(:text) { 'BarsFoosTa' }
+
+              it 'resolves the import' do
+                expect(subject).to eq(<<-EOS.strip)
+import BarsFoosTa from 'sko/bars/foos/ta';
+
+BarsFoosTa
+                EOS
+              end
             end
           end
         end

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -188,6 +188,58 @@ foo
           end
         end
 
+        context 'when the variable name matches last folder+filename' do
+          let(:existing_files) { ['sko/bar/foo.jsx'] }
+          let(:word) { 'barFoo' }
+          let(:text) { 'barFoo' }
+
+          it 'resolves the import' do
+            expect(subject).to eq(<<-EOS.strip)
+import barFoo from 'sko/bar/foo';
+
+barFoo
+            EOS
+          end
+
+          context 'when the last folder ends with an "s"' do
+            let(:existing_files) { ['sko/bars/foo.jsx'] }
+
+            it 'resolves the import' do
+              expect(subject).to eq(<<-EOS.strip)
+import barFoo from 'sko/bars/foo';
+
+barFoo
+              EOS
+            end
+          end
+        end
+
+        context 'when the variable name matches a few folders + filename' do
+          let(:existing_files) { ['sko/bar/foo/ta.jsx'] }
+          let(:word) { 'BarFooTa' }
+          let(:text) { 'BarFooTa' }
+
+          it 'resolves the import' do
+            expect(subject).to eq(<<-EOS.strip)
+import BarFooTa from 'sko/bar/foo/ta';
+
+BarFooTa
+            EOS
+          end
+
+          context 'when the folders end with "s"' do
+            let(:existing_files) { ['sko/bars/foos/ta.jsx'] }
+
+            it 'resolves the import' do
+              expect(subject).to eq(<<-EOS.strip)
+import BarFooTa from 'sko/bars/foos/ta';
+
+BarFooTa
+              EOS
+            end
+          end
+        end
+
         context "when there are other imports under 'use strict'" do
           let(:text) { <<-EOS.strip }
 'use strict';

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -225,6 +225,33 @@ barsFoo
               end
             end
           end
+
+          context 'when the last folder ends with "es"' do
+            let(:existing_files) { ['sko/statuses/foo.jsx'] }
+            let(:word) { 'statusFoo' }
+            let(:text) { 'statusFoo' }
+
+            it 'resolves the import' do
+              expect(subject).to eq(<<-EOS.strip)
+import statusFoo from 'sko/statuses/foo';
+
+statusFoo
+              EOS
+            end
+
+            context 'when the variable also has "es" at the end' do
+              let(:word) { 'statusesFoo' }
+              let(:text) { 'statusesFoo' }
+
+              it 'resolves the import' do
+                expect(subject).to eq(<<-EOS.strip)
+import statusesFoo from 'sko/statuses/foo';
+
+statusesFoo
+                EOS
+              end
+            end
+          end
         end
 
         context 'when the variable name matches a few folders + filename' do
@@ -260,6 +287,33 @@ BarFooTa
 import BarsFoosTa from 'sko/bars/foos/ta';
 
 BarsFoosTa
+                EOS
+              end
+            end
+          end
+
+          context 'when the folders end with "es"' do
+            let(:existing_files) { ['sko/statuses/buses/ta.jsx'] }
+            let(:word) { 'statusBusTa' }
+            let(:text) { 'statusBusTa' }
+
+            it 'resolves the import' do
+              expect(subject).to eq(<<-EOS.strip)
+import statusBusTa from 'sko/statuses/buses/ta';
+
+statusBusTa
+              EOS
+            end
+
+            context 'when the variable also has "es"' do
+              let(:word) { 'StatusesBusesTa' }
+              let(:text) { 'StatusesBusesTa' }
+
+              it 'resolves the import' do
+                expect(subject).to eq(<<-EOS.strip)
+import StatusesBusesTa from 'sko/statuses/buses/ta';
+
+StatusesBusesTa
                 EOS
               end
             end


### PR DESCRIPTION
This change will make e.g. app/mocks/Button.js get imported for a
variable named "MockButton". The fact that the full path was part of
matching was a somewhat unknown feature, since there were no tests (I've
added some in this commit). But we didn't take into account the fact
that it's rather common to name folders using a plural name of a thing.
Here are some examples:

  app/mocks # containing mock versions of a component
  app/tests # containing tests for a component

In #127, @lencioni describes a scenario where he wants a variable named
'mockMyComponent' to match a module located at `./mocks/MyComponent`. To
make that happen, I added an optional "s" to the regexp constructed for
a variable name. I'm aware that this will mostly just work for English,
but I think that's fine.

[Fixes #127]