### PR TITLE
Improve readability of find command in Importer

### DIFF
--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -250,10 +250,10 @@ module ImportJS
         "egrep -i \"(/|^)#{formatted_to_regex(variable_name)}(/index)?(/package)?\.js.*\""
       matched_modules = []
       @config.get('lookup_paths').each do |lookup_path|
-        find_command = [
-          "find #{lookup_path}",
-          "-name \"**.js*\"",
-          "-not -path \"./node_modules/*\""
+        find_command = %W[
+          find #{lookup_path}
+          -name "**.js*"
+          -not -path "./node_modules/*"
         ].join(' ')
         out, _ = Open3.capture3("#{find_command} | #{egrep_command}")
         matched_modules.concat(


### PR DESCRIPTION
Instead of using an array of interpolated strings which require escaping
double quotes, we can just use %W[...]. This matches how we build the
eslint command, which I switched to %w[...] in e60c556f.