### PR TITLE
Specify filename when running eslint via --stdin-filename

### DIFF
--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -90,8 +90,9 @@ module ImportJS
 
     # @return [Array<String>] the output from eslint, line by line
     def run_eslint_command
-      command = @config.get('eslint_executable') + ' ' + %w[
+      command = @config.get('eslint_executable') + ' ' + %W[
         --stdin
+        --stdin-filename #{@editor.path_to_current_file}
         --format unix
         --rule 'no-undef: 2'
         --rule 'no-unused-vars: [2, { "vars": "all", "args": "none" }]'

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -90,7 +90,8 @@ module ImportJS
 
     # @return [Array<String>] the output from eslint, line by line
     def run_eslint_command
-      command = @config.get('eslint_executable') + ' ' + %W[
+      command = %W[
+        #{@config.get('eslint_executable')}
         --stdin
         --stdin-filename #{@editor.path_to_current_file}
         --format unix


### PR DESCRIPTION
I am working in a project that has some files like:

  .eslintrc
  spec/javascripts/.eslintrc
  spec/javascripts/something_spec.js

The .eslintrc file in spec/javascripts defines some additional globals
that are not defined in the root .eslintrc file. When running
auto-import on a file in the spec/javscripts directory, I was seeing
messages saying that import-js could not find a matching module for `it`
or `describe`, etc. This was happening because we are passing the
contents of the file to eslint via stdin, so it had no way to know if it
should apply the .eslintrc found in spec/javascripts when running on
this file.

Thankfully, eslint provides an option that allows us to specify the path
the file passed via stdin. This commit passes this information down to
eslint, which resolves this issue for me.