### PR TITLE
Use FindError instead of ParseError when failing find

### DIFF
--- a/lib/import_js.rb
+++ b/lib/import_js.rb
@@ -6,6 +6,10 @@ module ImportJS
   class ParseError < StandardError
     # Error thrown when a JS file can't be parsed
   end
+
+  class FindError < StandardError
+    # Error thrown when the find command fails
+  end
 end
 
 require_relative 'import_js/command_line_editor'

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -252,6 +252,13 @@ module ImportJS
         "egrep -i \"(/|^)#{formatted_to_regex(variable_name)}(/index)?(/package)?\.js.*\""
       matched_modules = []
       @config.get('lookup_paths').each do |lookup_path|
+        if lookup_path == ''
+          # If lookup_path is an empty string, the `find` command will not work
+          # as desired so we bail early.
+          fail ImportJS::FindError.new,
+            "lookup path cannot be empty (#{lookup_path.inspect})"
+        end
+
         find_command = %W[
           find #{lookup_path}
           -name "**.js*"
@@ -260,7 +267,7 @@ module ImportJS
         command = "#{find_command} | #{egrep_command}"
         out, err = Open3.capture3(command)
 
-        fail ImportJS::ParseError.new, err unless err == ''
+        fail ImportJS::FindError.new, err unless err == ''
 
         matched_modules.concat(
           out.split("\n").map do |f|

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -67,6 +67,7 @@ describe ImportJS::Importer do
   let(:text) { 'foo' } # start with a simple buffer
   let(:existing_files) { [] } # start with a simple buffer
   let(:package_json_content) { nil }
+  let(:lookup_paths) { [@tmp_dir] }
 
   before do
     VIM.current_word = word
@@ -76,7 +77,7 @@ describe ImportJS::Importer do
     allow_any_instance_of(ImportJS::Configuration)
       .to receive(:get).and_call_original
     allow_any_instance_of(ImportJS::Configuration)
-      .to receive(:get).with('lookup_paths').and_return([@tmp_dir])
+      .to receive(:get).with('lookup_paths').and_return(lookup_paths)
     allow_any_instance_of(ImportJS::VIMEditor)
       .to receive(:available_columns).and_return(100)
     allow_any_instance_of(ImportJS::VIMEditor)
@@ -103,6 +104,14 @@ describe ImportJS::Importer do
     subject do
       described_class.new.import
       VIM::Buffer.current_buffer.to_s
+    end
+
+    context 'when lookup_paths is just an empty string' do
+      let(:lookup_paths) { [''] }
+
+      it 'throws an error' do
+        expect { subject }.to raise_error(ImportJS::FindError)
+      end
     end
 
     context 'with a variable name that will not resolve' do


### PR DESCRIPTION
As @trotzig pointed out, ParseError isn't ideal here. So I decided to
replace it with a FindError and add a test to verify that it works.