### PR TITLE
Simplify JSModule construction

### DIFF
--- a/lib/import_js/configuration.rb
+++ b/lib/import_js/configuration.rb
@@ -44,18 +44,15 @@ module ImportJS
         path = path.sub(/\{filename\}/,
                         File.basename(path_to_current_file, '.*'))
       end
-      ImportJS::JSModule.new(lookup_path: nil,
-                             relative_file_path: path,
-                             strip_file_extensions: [])
+      ImportJS::JSModule.new(import_path: path)
+
     end
 
     def resolve_destructured_alias(variable_name)
       @config['aliases'].each do |_, path|
         next if path.is_a? String
         if (path['destructure'] || []).include?(variable_name)
-          js_module = ImportJS::JSModule.new(lookup_path: nil,
-                                             relative_file_path: path['path'],
-                                             strip_file_extensions: [])
+          js_module = ImportJS::JSModule.new(import_path: path['path'])
           js_module.is_destructured = true
           return js_module
         end

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -274,16 +274,13 @@ module ImportJS
             next if @config.get('excludes').any? do |glob_pattern|
               File.fnmatch(glob_pattern, f)
             end
-            js_module = ImportJS::JSModule.new(
+            ImportJS::JSModule.construct(
               lookup_path: lookup_path,
               relative_file_path: f,
               strip_file_extensions: @config.get('strip_file_extensions'),
               make_relative_to: @config.get('use_relative_paths') &&
                                 path_to_current_file
             )
-
-            next if js_module.skip
-            js_module
           end.compact
         )
       end
@@ -296,12 +293,11 @@ module ImportJS
            ignore_prefixes.any? do |prefix|
              dep.sub(/^#{prefix}/, '') =~ dep_matcher
            end
-          js_module = ImportJS::JSModule.new(
+          js_module = ImportJS::JSModule.construct(
             lookup_path: 'node_modules',
             relative_file_path: "node_modules/#{dep}/package.json",
             strip_file_extensions: [])
-          next if js_module.skip
-          matched_modules << js_module
+          matched_modules << js_module if js_module
         end
       end
 

--- a/spec/import_js/js_module_spec.rb
+++ b/spec/import_js/js_module_spec.rb
@@ -7,7 +7,7 @@ describe ImportJS::JSModule do
   let(:strip_file_extensions) { ['.js'] }
 
   subject do
-    described_class.new(
+    described_class.construct(
       lookup_path: lookup_path,
       relative_file_path: relative_file_path,
       strip_file_extensions: strip_file_extensions,


### PR DESCRIPTION
I've been wanting to refactor the way JSModule instances were created
for a while. Instance variables were assigned and re-assigned without
much control, and there was some mutation in place that was prone to
subtle errors.

Instead of handling everything in the constructor, I introduced a
factory method that delegates to a few other methods. When the real
constructor was freed up, I was able to simplify both the factory by
allowing direct instantiations in a few places (e.g. for aliases).

I expect this change to have no functional changes. It should be a
straight one-to-one mapping (if I got everything right).