### PR TITLE
Auto-import React if implicit dependency exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,13 @@ automatically fix all imports. By hiting `<leader>i` (Vim), `(M-x)
 import-js-fix` (Emacs), or choose `ImportJS: fix all imports` (Sublime), all
 your undefined variables will be resolved, and all your unused imports will be
 removed. By default, import-js expects a global `eslint` command to be
-available.
+available, but you can change that with the [`eslint_executable` configuration
+option](#eslint_executable).
+
+If you're using React, import-js will automatically import `React` for you, but
+only if you have
+[eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react)
+installed and enabled in your `.eslintrc` configuration file.
 
 ## Experimental: Go to module
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ option](#eslint_executable).
 If you're using React, import-js will automatically import `React` for you, but
 only if you have
 [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react)
-installed and enabled in your `.eslintrc` configuration file.
+installed and the
+[`react-in-jsx-scope`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md)
+rule enabled in your `.eslintrc` configuration file.
 
 ## Experimental: Go to module
 

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -57,6 +57,7 @@ module ImportJS
       @config = ImportJS::Configuration.new(@editor.path_to_current_file)
       eslint_result = run_eslint_command
       undefined_variables = eslint_result.map do |line|
+        next 'React' if line =~ /'React' must be in scope when using JSX/
         /(["'])([^"']+)\1 is not defined/.match(line) do |match_data|
           match_data[2]
         end


### PR DESCRIPTION
By allowing import-js to know about eslint output from a specific plugin
(react-in-jsx-scope [1]). This isn't great, but it solves an important
usecase when using jsx, namely that `React` must be in scope when trying
to do stuff like

  import 'Button' from 'components/button';
  const button = <Button/>;

I added a section to the Readme to explain how this feature works. While
doing that, I improved the section about eslint a little bit.

Fixes #113

[1]: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md