### PR TITLE
Add .rubocop.yml, fix many rubocop errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,17 @@
+AllCops:
+  DisplayCopNames: true
+
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': '[]'
+    '%w': '[]'
+    '%W': '[]'
+
+Metrics/AbcSize:
+  Max: 18
+
+Metrics/MethodLength:
+  Max: 18

--- a/bin/import-js
+++ b/bin/import-js
@@ -9,7 +9,7 @@ opts = Slop.parse do |o|
   o.bool '--goto', 'instead of importing, just print the path to a module'
   o.array '--selections', 'a list of resolved selections, e.g. Foo:0,Bar:1'
   o.string '--filename',
-    'a path to the file which contents are being passed in as stdin'
+           'a path to the file which contents are being passed in as stdin'
   o.on '-v', '--version', 'print the current version' do
     puts ImportJS::VERSION
     exit
@@ -50,7 +50,7 @@ end
 
 # Print messages to stderr
 meta = {
-  messages: editor.messages
+  messages: editor.messages,
 }
 ask = editor.ask_for_selections
 meta[:ask_for_selections] = ask unless ask.empty?

--- a/lib/import_js/command_line_editor.rb
+++ b/lib/import_js/command_line_editor.rb
@@ -1,4 +1,5 @@
 module ImportJS
+  # This is the implementation of command line integration in Import-JS.
   class CommandLineEditor
     def initialize(lines, opts)
       @lines = lines
@@ -24,20 +25,14 @@ module ImportJS
       @goto = file_path
     end
 
-    # @return [String]
-    def goto
-      @goto
-    end
+    attr_reader :goto
 
     # @param str [String]
     def message(str)
       @messages << str
     end
 
-    # @return [Array]
-    def ask_for_selections
-      @ask_for_selections
-    end
+    attr_reader :ask_for_selections
 
     # @return [String]
     def current_file_content
@@ -110,7 +105,7 @@ module ImportJS
       else
         @ask_for_selections << {
           word: word,
-          alternatives: alternatives
+          alternatives: alternatives,
         }
         nil
       end

--- a/lib/import_js/configuration.rb
+++ b/lib/import_js/configuration.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
 require 'json'
 require 'open3'
 
 module ImportJS
-  CONFIG_FILE = '.importjs.json'
+  CONFIG_FILE = '.importjs.json'.freeze
 
   DEFAULT_CONFIG = {
     'aliases' => {},
@@ -15,8 +16,8 @@ module ImportJS
     'lookup_paths' => ['.'],
     'strip_file_extensions' => ['.js', '.jsx'],
     'strip_from_path' => nil,
-    'use_relative_paths' => false
-  }
+    'use_relative_paths' => false,
+  }.freeze
 
   # Class that initializes configuration from a .importjs.json file
   class Configuration
@@ -33,7 +34,7 @@ module ImportJS
       @configs.find do |config|
         applies_to = config['applies_to'] || '*'
         applies_from = config['applies_from'] || '*'
-        next unless config.has_key?(key)
+        next unless config.key?(key)
         File.fnmatch(normalize_path(applies_to), @path_to_current_file) &&
           File.fnmatch(normalize_path(applies_from), normalize_path(from_file))
       end[key]
@@ -58,11 +59,11 @@ module ImportJS
     def resolve_destructured_alias(variable_name)
       get('aliases').each do |_, path|
         next if path.is_a? String
-        if (path['destructure'] || []).include?(variable_name)
-          js_module = ImportJS::JSModule.new(import_path: path['path'])
-          js_module.is_destructured = true
-          return js_module
-        end
+        next unless (path['destructure'] || []).include?(variable_name)
+
+        js_module = ImportJS::JSModule.new(import_path: path['path'])
+        js_module.is_destructured = true
+        return js_module
       end
       nil
     end
@@ -71,7 +72,7 @@ module ImportJS
     def package_dependencies
       return [] unless File.exist?('package.json')
 
-      keys = %w( dependencies peerDependencies )
+      keys = %w[dependencies peerDependencies]
       keys << 'devDependencies' if get('import_dev_dependencies')
       package_json = JSON.parse(File.read('package.json'))
       keys.map do |key|

--- a/lib/import_js/emacs_editor.rb
+++ b/lib/import_js/emacs_editor.rb
@@ -1,159 +1,159 @@
 # encoding: utf-8
 module ImportJS
-end
+  # This is the implementation of the emacs integration in Import-JS.
+  class EmacsEditor
+    attr_accessor :current_word
 
-class ImportJS::EmacsEditor
-  attr_accessor :current_word
+    def initialize
+      loop do
+        input = gets.chomp
+        command, value, path = input.split(':')
 
-  def initialize
-    loop do
-      input = gets.chomp
-      command, value, path = input.split(':')
+        begin
+          @path = path
+          @file = File.readlines(path).map(&:chomp)
+          @current_word = value
 
-      begin
-        @path = path
-        @file = File.readlines(path).map(&:chomp)
-        @current_word = value
-
-        case command
-        when 'import'
-          ImportJS::Importer.new(self).import
-          write_file
-          puts 'import:success'
-        when 'goto'
-          ImportJS::Importer.new(self).goto
-        when 'fix'
-          ImportJS::Importer.new(self).fix_imports
-          write_file
-          puts 'import:success'
-        else
-          puts "unknown command: #{command}"
+          case command
+          when 'import'
+            ImportJS::Importer.new(self).import
+            write_file
+            puts 'import:success'
+          when 'goto'
+            ImportJS::Importer.new(self).goto
+          when 'fix'
+            ImportJS::Importer.new(self).fix_imports
+            write_file
+            puts 'import:success'
+          else
+            puts "unknown command: #{command}"
+          end
+        rescue Exception => e
+          puts e.inspect
         end
-      rescue Exception => e
-        puts e.inspect
       end
     end
-  end
 
-  def write_file
-    new_file = File.open(@path, 'w')
-    @file.each {|line| new_file.puts(line) }
-    new_file.close
-  end
-
-  # Open a file specified by a path.
-  #
-  # @param file_path [String]
-  def open_file(file_path)
-    puts "goto:success:#{File.expand_path(file_path)}"
-  end
-
-  # Get the path to the file currently being edited. May return `nil` if an
-  # anonymous file is being edited.
-  #
-  # @return [String?]
-  def path_to_current_file
-    @path
-  end
-
-  # Display a message to the user.
-  #
-  # @param str [String]
-  def message(str)
-    puts str
-  end
-
-  # Read the entire file into a string.
-  #
-  # @return [String]
-  def current_file_content
-    @file.join("\n")
-  end
-
-  # Reads a line from the file.
-  #
-  # Lines are one-indexed, so 1 means the first line in the file.
-  # @return [String]
-  def read_line(line_number)
-    @file[line_number - 1]
-  end
-
-  # Get the cursor position.
-  #
-  # @return [Array(Number, Number)]
-  def cursor
-    return 0, 0
-  end
-
-  # Place the cursor at a specified position.
-  #
-  # @param position_tuple [Array(Number, Number)] the row and column to place
-  #   the cursor at.
-  def cursor=(position_tuple)
-  end
-
-  # Delete a line.
-  #
-  # @param line_number [Number] One-indexed line number.
-  #   1 is the first line in the file.
-  def delete_line(line_number)
-    @file.delete_at(line_number - 1)
-  end
-
-  # Append a line right after the specified line.
-  #
-  # Lines are one-indexed, but you need to support appending to line 0 (add
-  # content at top of file).
-  # @param line_number [Number]
-  def append_line(line_number, str)
-    @file.insert(line_number, str)
-  end
-
-  # Count the number of lines in the file.
-  #
-  # @return [Number] the number of lines in the file
-  def count_lines
-    @file.size
-  end
-
-  # Ask the user to select something from a list of alternatives.
-  #
-  # @param word [String] The word/variable to import
-  # @param alternatives [Array<String>] A list of alternatives
-  # @return [Number, nil] the index of the selected alternative, or nil if
-  #   nothing was selected.
-  def ask_for_selection(word, alternatives)
-    puts "asking for selection"
-    puts "ImportJS: Pick JS module to import for '#{word}':"
-    puts JSON.pretty_generate(alternatives)
-    return
-
-    # need to implement this
-    escaped_list = [heading]
-    escaped_list << alternatives.each_with_index.map do |alternative, i|
-      "\"#{i + 1}: #{alternative}\""
+    def write_file
+      new_file = File.open(@path, 'w')
+      @file.each { |line| new_file.puts(line) }
+      new_file.close
     end
-    escaped_list_string = '[' + escaped_list.join(',') + ']'
 
-    selected_index = VIM.evaluate("inputlist(#{escaped_list_string})")
-    return if selected_index < 1
-    selected_index - 1
-  end
+    # Open a file specified by a path.
+    #
+    # @param file_path [String]
+    def open_file(file_path)
+      puts "goto:success:#{File.expand_path(file_path)}"
+    end
 
-  # Get the preferred max length of a line
-  # @return [Number?]
-  def max_line_length
-    80
-  end
+    # Get the path to the file currently being edited. May return `nil` if an
+    # anonymous file is being edited.
+    #
+    # @return [String?]
+    def path_to_current_file
+      @path
+    end
 
-  # @return [String] shiftwidth number of spaces if expandtab is not set,
-  #   otherwise `\t`
-  def tab
-    return ' ' * shift_width || 2
-  end
+    # Display a message to the user.
+    #
+    # @param str [String]
+    def message(str)
+      puts str
+    end
 
-  # @return [Number?]
-  def shift_width
-    2
+    # Read the entire file into a string.
+    #
+    # @return [String]
+    def current_file_content
+      @file.join("\n")
+    end
+
+    # Reads a line from the file.
+    #
+    # Lines are one-indexed, so 1 means the first line in the file.
+    # @return [String]
+    def read_line(line_number)
+      @file[line_number - 1]
+    end
+
+    # Get the cursor position.
+    #
+    # @return [Array(Number, Number)]
+    def cursor
+      [0, 0]
+    end
+
+    # Place the cursor at a specified position.
+    #
+    # @param position_tuple [Array(Number, Number)] the row and column to place
+    #   the cursor at.
+    def cursor=(position_tuple)
+    end
+
+    # Delete a line.
+    #
+    # @param line_number [Number] One-indexed line number.
+    #   1 is the first line in the file.
+    def delete_line(line_number)
+      @file.delete_at(line_number - 1)
+    end
+
+    # Append a line right after the specified line.
+    #
+    # Lines are one-indexed, but you need to support appending to line 0 (add
+    # content at top of file).
+    # @param line_number [Number]
+    def append_line(line_number, str)
+      @file.insert(line_number, str)
+    end
+
+    # Count the number of lines in the file.
+    #
+    # @return [Number] the number of lines in the file
+    def count_lines
+      @file.size
+    end
+
+    # Ask the user to select something from a list of alternatives.
+    #
+    # @param word [String] The word/variable to import
+    # @param alternatives [Array<String>] A list of alternatives
+    # @return [Number, nil] the index of the selected alternative, or nil if
+    #   nothing was selected.
+    def ask_for_selection(word, alternatives)
+      puts 'asking for selection'
+      puts "ImportJS: Pick JS module to import for '#{word}':"
+      puts JSON.pretty_generate(alternatives)
+      return
+
+      # need to implement this
+      escaped_list = [heading]
+      escaped_list << alternatives.each_with_index.map do |alternative, i|
+        "\"#{i + 1}: #{alternative}\""
+      end
+      escaped_list_string = '[' + escaped_list.join(',') + ']'
+
+      selected_index = VIM.evaluate("inputlist(#{escaped_list_string})")
+      return if selected_index < 1
+      selected_index - 1
+    end
+
+    # Get the preferred max length of a line
+    # @return [Number?]
+    def max_line_length
+      80
+    end
+
+    # @return [String] shiftwidth number of spaces if expandtab is not set,
+    #   otherwise `\t`
+    def tab
+      ' ' * shift_width || 2
+    end
+
+    # @return [Number?]
+    def shift_width
+      2
+    end
   end
 end

--- a/lib/import_js/import_statement.rb
+++ b/lib/import_js/import_statement.rb
@@ -4,9 +4,9 @@ module ImportJS
   # `let foo = myCustomRequire('foo');`
   # `import foo from 'foo';`
   class ImportStatement
-    REGEX_CONST_LET_VAR = %r{
+    REGEX_CONST_LET_VAR = /
       \A
-      (?<declaration_keyword>const|let|var)\s+ # <declaration_keyword> assignment
+      (?<declaration_keyword>const|let|var)\s+ # <declaration_keyword>
       (?<assignment>.+?)   # <assignment> variable assignment
       \s*=\s*
       (?<import_function>[^\(]+?)\( # <import_function> variable assignment
@@ -15,20 +15,20 @@ module ImportJS
         \k<quote>          # closing quote
       \);?
       \s*
-    }xm
+    /xm
 
-    REGEX_IMPORT = %r{
+    REGEX_IMPORT = /
       \A
-      (?<declaration_keyword>import)\s+ # <declaration_keyword> assignment
+      (?<declaration_keyword>import)\s+ # <declaration_keyword>
       (?<assignment>.*?) # <assignment> variable assignment
       \s+from\s+
       (?<quote>'|")      # <quote> opening quote
       (?<path>[^\2]+)    # <path> module path
       \k<quote>          # closing quote
       ;?\s*
-    }xm
+    /xm
 
-    REGEX_DESTRUCTURE = %r{
+    REGEX_DESTRUCTURE = /
       (?:                    # non-capturing group
         (?<default>.*?)      # <default> variable
         ,\s*
@@ -38,7 +38,7 @@ module ImportJS
         (?<destructured>.*)  # <destructured> variables
         \s*
       \}
-    }xm
+    /xm
 
     attr_accessor :assignment
     attr_accessor :declaration_keyword
@@ -67,7 +67,8 @@ module ImportJS
       if match.names.include? 'import_function'
         statement.import_function = match[:import_function]
       end
-      if dest_match = statement.assignment.match(REGEX_DESTRUCTURE)
+      dest_match = statement.assignment.match(REGEX_DESTRUCTURE)
+      if dest_match
         statement.default_variable = dest_match[:default]
         statement.destructured_variables =
           dest_match[:destructured].split(/,\s*/).map(&:strip)
@@ -207,7 +208,8 @@ module ImportJS
       end
 
       destructured = "{ #{destructured_variables.join(', ')} }"
-      line = "#{declaration_keyword} #{prefix}#{destructured} #{equals} #{value}"
+      line = "#{declaration_keyword} #{prefix}#{destructured} #{equals} " \
+        "#{value}"
       return line unless line_too_long?(line, max_line_length)
 
       destructured = "{\n#{tab}#{destructured_variables.join(",\n#{tab}")},\n}"

--- a/lib/import_js/js_module.rb
+++ b/lib/import_js/js_module.rb
@@ -31,7 +31,7 @@ module ImportJS
       return unless import_path
 
       import_path = import_path.sub(
-        /^#{Regexp.escape(js_module.lookup_path)}\//, '')
+        %r{^#{Regexp.escape(js_module.lookup_path)}/}, '')
 
       js_module.import_path = import_path
       js_module.main_file = main_file
@@ -44,7 +44,7 @@ module ImportJS
     # @return [String]
     def self.normalize_path(path)
       return unless path
-      path.sub(/^\.\/?/, '')
+      path.sub(%r{^\./?}, '')
     end
 
     # @param file_path [String]
@@ -54,12 +54,12 @@ module ImportJS
       if file_path.end_with? '/package.json'
         main_file = JSON.parse(File.read(file_path))['main']
         return [nil, nil] unless main_file
-        match = file_path.match(/(.*)\/package\.json/)
+        match = file_path.match(%r{(.*)/package\.json})
         return match[1], main_file
       end
 
-      if file_path.match(%r{/index\.js[^/]*$})
-        match = file_path.match(/(.*)\/(index\.js.*)/)
+      if file_path =~ %r{/index\.js[^/]*$}
+        match = file_path.match(%r{(.*)/(index\.js.*)})
         return match[1], match[2]
       end
 
@@ -82,14 +82,14 @@ module ImportJS
     def make_relative_to(make_relative_to)
       return unless lookup_path
       # First, strip out any absolute path up until the current directory
-      make_relative_to = make_relative_to.sub(Dir.pwd + "\/", '')
+      make_relative_to = make_relative_to.sub("#{Dir.pwd}/", '')
 
       # Ignore if the file to relate to is part of a different lookup_path
       return unless make_relative_to.start_with? lookup_path
 
       # Strip out the lookup_path
       make_relative_to = make_relative_to.sub(
-        /^#{Regexp.escape(lookup_path)}\//, '')
+        %r{^#{Regexp.escape(lookup_path)}/}, '')
 
       path = Pathname.new(import_path).relative_path_from(
         Pathname.new(File.dirname(make_relative_to))

--- a/lib/import_js/version.rb
+++ b/lib/import_js/version.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 # Defines the gem version.
 module ImportJS
-  VERSION = '0.3.1'
+  VERSION = '0.3.1'.freeze
 end

--- a/lib/import_js/vim_editor.rb
+++ b/lib/import_js/vim_editor.rb
@@ -145,13 +145,13 @@ module ImportJS
     # @param name [String]
     # @return [Number?]
     def get_number(name)
-      exists?(name) ? VIM.evaluate("#{name}").to_i : nil
+      exists?(name) ? VIM.evaluate(name).to_i : nil
     end
 
     # @param name [String]
     # @return [Boolean?]
     def get_bool(name)
-      exists?(name) ? VIM.evaluate("#{name}").to_i != 0 : nil
+      exists?(name) ? VIM.evaluate(name).to_i != 0 : nil
     end
 
     # @return [Boolean?]

--- a/spec/import_js/configuration_spec.rb
+++ b/spec/import_js/configuration_spec.rb
@@ -10,15 +10,16 @@ describe ImportJS::Configuration do
       let(:configuration) do
         {
           'aliases' => { 'foo' => 'bar' },
-          'declaration_keyword' => 'const'
+          'declaration_keyword' => 'const',
         }
       end
 
       before do
         allow_any_instance_of(ImportJS::Configuration)
           .to receive(:load_config).and_return(nil)
-        allow_any_instance_of(ImportJS::Configuration).to receive(:load_config).with(
-          '.importjs.json').and_return(configuration)
+        allow_any_instance_of(ImportJS::Configuration)
+          .to receive(:load_config).with('.importjs.json')
+          .and_return(configuration)
       end
 
       it 'returns the configured value for the key' do
@@ -26,16 +27,19 @@ describe ImportJS::Configuration do
       end
 
       context 'when there are multiple configs in the .importjs.json file' do
-        let(:path_to_current_file) { File.join(Dir.pwd, 'goo', 'gar', 'gaz.js') }
+        let(:path_to_current_file) do
+          File.join(Dir.pwd, 'goo', 'gar', 'gaz.js')
+        end
+
         let(:configuration) do
           [
             {
               'declaration_keyword' => 'let',
-              'import_function' => 'foobar'
+              'import_function' => 'foobar',
             },
             {
               'applies_to' => 'goo/**',
-              'declaration_keyword' => 'var'
+              'declaration_keyword' => 'var',
             },
           ]
         end
@@ -45,7 +49,7 @@ describe ImportJS::Configuration do
             expect(subject.get('declaration_keyword')).to eq('var')
           end
 
-          it 'falls back to global config if key is missing from local config' do
+          it 'falls back to global config if key missing from local config' do
             expect(subject.get('import_function')).to eq('foobar')
           end
 
@@ -79,8 +83,8 @@ describe ImportJS::Configuration do
             {
               'applies_to' => 'goo/**',
               'applies_from' => 'from/**',
-              'declaration_keyword' => 'var'
-            }
+              'declaration_keyword' => 'var',
+            },
           ]
         end
 
@@ -146,13 +150,13 @@ describe ImportJS::Configuration do
           {
             'dependencies' => {
               'foo' => '1.0.0',
-              'bar' => '2.0.0'
-            }
+              'bar' => '2.0.0',
+            },
           }
         end
 
         it 'returns those dependencies' do
-          expect(subject.package_dependencies).to eq(['foo', 'bar'])
+          expect(subject.package_dependencies).to eq(%w[foo bar])
         end
       end
 
@@ -163,13 +167,13 @@ describe ImportJS::Configuration do
               'foo' => '1.0.0',
             },
             'peerDependencies' => {
-              'bar' => '2.0.0'
-            }
+              'bar' => '2.0.0',
+            },
           }
         end
 
         it 'returns combined dependencies' do
-          expect(subject.package_dependencies).to eq(['foo', 'bar'])
+          expect(subject.package_dependencies).to eq(%w[foo bar])
         end
       end
 
@@ -180,8 +184,8 @@ describe ImportJS::Configuration do
               'foo' => '1.0.0',
             },
             'devDependencies' => {
-              'bar' => '2.0.0'
-            }
+              'bar' => '2.0.0',
+            },
           }
         end
 
@@ -196,7 +200,7 @@ describe ImportJS::Configuration do
           end
 
           it 'returns devDependencies as well' do
-            expect(subject.package_dependencies).to eq(['foo', 'bar'])
+            expect(subject.package_dependencies).to eq(%w[foo bar])
           end
         end
       end

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -81,7 +81,8 @@ describe ImportJS::Importer do
     allow_any_instance_of(ImportJS::VIMEditor)
       .to receive(:available_columns).and_return(100)
     allow_any_instance_of(ImportJS::VIMEditor)
-      .to receive(:path_to_current_file).and_return(File.join(@tmp_dir, 'test.js'))
+      .to receive(:path_to_current_file)
+      .and_return(File.join(@tmp_dir, 'test.js'))
 
     existing_files.each do |file|
       full_path = File.join(@tmp_dir, file)
@@ -136,7 +137,9 @@ describe ImportJS::Importer do
       it 'displays a message' do
         subject
         expect(VIM.last_command_message).to eq(
-          'ImportJS: No variable to import. Place your cursor on a variable, then try again.')
+          'ImportJS: No variable to import. Place your cursor on a variable, '\
+          'then try again.'
+        )
       end
 
       context 'when Vim is narrower than the message' do
@@ -148,7 +151,9 @@ describe ImportJS::Importer do
         it 'truncates the message' do
           subject
           expect(VIM.last_command_message).to eq(
-            'ImportJS: No variable to import. Place your cursor on a variable, then try aga…')
+            'ImportJS: No variable to import. Place your cursor on a '\
+            'variable, then try aga…'
+          )
         end
       end
     end
@@ -256,7 +261,7 @@ foo
           end
         end
 
-        context 'when multiple one-line comments and empty lines are at the top of the file' do
+        context 'when one-line comments with empty lines are at the top' do
           let(:text) { <<-EOS.strip }
 // One-line comment
 
@@ -296,7 +301,7 @@ foo
           end
         end
 
-        context 'when a multi-line comment that spans multiple lines is at the top of the file' do
+        context 'when a multi-line comment that spans lines is at the top' do
           let(:text) { <<-EOS.strip }
 /*
   Multi-line comment
@@ -320,7 +325,7 @@ foo
           end
         end
 
-        context 'when a one-line and multi-line comment are at the top of the file' do
+        context 'when both comment styles are at the top of the file' do
           let(:text) { <<-EOS.strip }
 // One-line comment
 /* Multi-line comment */
@@ -792,7 +797,7 @@ foo
           [
             'bar/foo.jsx',
             'zoo/foo.js',
-            'zoo/goo/Foo/index.js'
+            'zoo/goo/Foo/index.js',
           ]
         end
 
@@ -880,13 +885,13 @@ foo
           [
             'Foo/lib/foo.jsx',
             'Foo/package.json',
-            'zoo/foo.js'
+            'zoo/foo.js',
           ]
         end
 
         let(:package_json_content) do
           {
-            main: 'lib/foo.jsx'
+            main: 'lib/foo.jsx',
           }
         end
 
@@ -910,7 +915,7 @@ foo
       context 'when `main` points to a JS file' do
         let(:package_json_content) do
           {
-            main: 'build/main.js'
+            main: 'build/main.js',
           }
         end
 
@@ -928,7 +933,7 @@ foo
 
         let(:package_json_content) do
           {
-            main: 'index.js'
+            main: 'index.js',
           }
         end
 
@@ -1077,7 +1082,7 @@ foo
       context 'with aliases' do
         let(:configuration) do
           {
-            'aliases' => { '$' => 'jquery' }
+            'aliases' => { '$' => 'jquery' },
           }
         end
         let(:text) { '$' }
@@ -1100,7 +1105,7 @@ $
 
           let(:configuration) do
             {
-              'aliases' => { 'styles' => './{filename}.scss' }
+              'aliases' => { 'styles' => './{filename}.scss' },
             }
           end
           let(:text) { 'styles' }
@@ -1146,7 +1151,7 @@ styles
           # https://github.com/trotzig/import-js/issues/39
           let(:configuration) do
             {
-              'aliases' => { '$' => 'jquery/jquery' }
+              'aliases' => { '$' => 'jquery/jquery' },
             }
           end
 
@@ -1167,12 +1172,12 @@ $
             'aliases' => {
               '_' => {
                 'path' => 'underscore',
-                'destructure' => %w(
+                'destructure' => %w[
                   memoize
                   debounce
-                )
-              }
-            }
+                ],
+              },
+            },
           }
         end
         let(:text) { '_' }
@@ -1232,7 +1237,7 @@ memoize
             end
           end
 
-          context 'when the default import exists for the same module with other modules' do
+          context 'when the default is already imported for destructured var' do
             let(:text) { <<-EOS.strip }
 var _ = require('underscore');
 var foo = require('foo');
@@ -1311,12 +1316,12 @@ memoize
             'aliases' => {
               '_' => {
                 'path' => 'underscore',
-                'destructure' => %w(
+                'destructure' => %w[
                   memoize
                   debounce
-                )
-              }
-            }
+                ],
+              },
+            },
           }
         end
         let(:text) { '_' }
@@ -1450,7 +1455,7 @@ memoize
           let(:configuration) do
             {
               'import_function' => 'myRequire',
-              'declaration_keyword' => 'import'
+              'declaration_keyword' => 'import',
             }
           end
 
@@ -1467,7 +1472,7 @@ foo
           let(:configuration) do
             {
               'import_function' => 'myRequire',
-              'declaration_keyword' => 'const'
+              'declaration_keyword' => 'const',
             }
           end
           it 'uses the custom import function instead of "require"' do
@@ -1484,7 +1489,7 @@ foo
         let(:existing_files) { ['bar/foo.js'] }
         let(:configuration) do
           {
-            'strip_file_extensions' => []
+            'strip_file_extensions' => [],
           }
         end
 
@@ -1501,7 +1506,7 @@ foo
         let(:existing_files) { ['bar/foo/foo.js'] }
         let(:configuration) do
           {
-            'excludes' => ['**/foo/**']
+            'excludes' => ['**/foo/**'],
           }
         end
 
@@ -1526,14 +1531,14 @@ foo
 
         let(:configuration) do
           {
-            'declaration_keyword' => 'const'
+            'declaration_keyword' => 'const',
           }
         end
 
         context 'with a variable name that will resolve' do
           let(:existing_files) { ['bar/foo.jsx'] }
 
-          it 'adds an import to the top of the buffer using the declaration_keyword' do
+          it 'adds an import to the top using the declaration_keyword' do
             expect(subject).to eq(<<-EOS.strip)
 const foo = require('bar/foo');
 
@@ -1565,7 +1570,7 @@ var foo =
 foo
             EOS
 
-            it 'changes the `var` to declaration_keyword and removes the whitespace' do
+            it 'changes the `var` to declaration_keyword and removes space' do
               expect(subject).to eq(<<-EOS.strip)
 const foo = require('bar/foo');
 
@@ -1603,7 +1608,7 @@ foo
 
         let(:configuration) do
           {
-            'declaration_keyword' => 'import'
+            'declaration_keyword' => 'import',
           }
         end
 
@@ -1626,14 +1631,14 @@ foo
             end
           end
 
-          context 'when that variable is already imported using `var` and double quotes' do
+          context 'when that variable already exists with a different style' do
             let(:text) { <<-EOS.strip }
 var foo = require("bar/foo");
 
 foo
             EOS
 
-            it 'changes the `var` to declaration_keyword and doubles to singles' do
+            it 'changes `var` to declaration_keyword and doubles to singles' do
               expect(subject).to eq(<<-EOS.strip)
 import foo from 'bar/foo';
 
@@ -1642,7 +1647,7 @@ foo
             end
           end
 
-          context 'when that variable is already imported and has "from" in it' do
+          context 'when the imported variable has "from" in it' do
             let(:text) { <<-EOS.strip }
 var fromfoo = require('bar/fromfoo');
 
@@ -1667,7 +1672,7 @@ var foo =
 foo
             EOS
 
-            it 'changes the `var` to declaration_keyword and removes the whitespace' do
+            it 'changes the `var` to declaration_keyword and removes space' do
               expect(subject).to eq(<<-EOS.strip)
 import foo from 'bar/foo';
 
@@ -1716,7 +1721,7 @@ foo
 
         let(:configuration) do
           {
-            'use_relative_paths' => true
+            'use_relative_paths' => true,
           }
         end
 
@@ -1751,7 +1756,7 @@ foo
         let(:configuration) do
           [{
             'applies_to' => pattern,
-            'declaration_keyword' => 'var'
+            'declaration_keyword' => 'var',
           }]
         end
         before do
@@ -1908,7 +1913,7 @@ foo
     context 'when one undefined variable exists' do
       let(:existing_files) { ['bar/foo.jsx'] }
       let(:eslint_result) do
-        "stdin:3:11: \"foo\" is not defined. [Error/no-undef]"
+        'stdin:3:11: "foo" is not defined. [Error/no-undef]'
       end
 
       it 'imports that variable' do
@@ -1937,8 +1942,9 @@ foo
 
       context 'when eslint returns other issues' do
         let(:eslint_result) do
-          "stdin:1:1: Use the function form of \"use strict\". [Error/strict]\n" \
-          "stdin:3:11: \"foo\" is not defined. [Error/no-undef]"
+          'stdin:1:1: Use the function form of "use strict". ' \
+          "[Error/strict]\n" \
+          'stdin:3:11: "foo" is not defined. [Error/no-undef]'
         end
 
         it 'still imports the import' do
@@ -1957,7 +1963,7 @@ foo
 
       let(:eslint_result) do
         "stdin:3:11: \"foo\" is not defined. [Error/no-undef]\n" \
-        "stdin:3:11: \"bar\" is not defined. [Error/no-undef]"
+        'stdin:3:11: "bar" is not defined. [Error/no-undef]'
       end
 
       it 'imports all variables' do
@@ -1975,10 +1981,10 @@ var a = foo + bar;
       let(:text) { 'var a = foo + bar;' }
 
       let(:eslint_result) do
-        "stdin:3:11: \"foo\" is not defined. [Error/no-undef]\n" +
-        "stdin:3:11: \"foo\" is not defined. [Error/no-undef]\n" +
-        "stdin:3:11: \"foo\" is not defined. [Error/no-undef]\n" +
-        "stdin:3:11: \"bar\" is not defined. [Error/no-undef]"
+        "stdin:3:11: \"foo\" is not defined. [Error/no-undef]\n" \
+        "stdin:3:11: \"foo\" is not defined. [Error/no-undef]\n" \
+        "stdin:3:11: \"foo\" is not defined. [Error/no-undef]\n" \
+        'stdin:3:11: "bar" is not defined. [Error/no-undef]'
       end
 
       it 'imports all variables' do
@@ -2011,7 +2017,7 @@ var a = <span/>;
           allow_any_instance_of(ImportJS::Configuration)
             .to receive(:package_dependencies).and_return(['react'])
           allow(File).to receive(:read)
-            .with("node_modules/react/package.json")
+            .with('node_modules/react/package.json')
             .and_return('{ "main": "index.jsx" }')
         end
 
@@ -2039,7 +2045,7 @@ import foo from 'bar/foo';
 bar
       EOS
       let(:eslint_result) do
-        "stdin:1:4: \"foo\" is defined but never used [Error/no-unused-vars]"
+        'stdin:1:4: "foo" is defined but never used [Error/no-unused-vars]'
       end
 
       it 'removes that import' do
@@ -2061,8 +2067,9 @@ baz
       EOS
 
       let(:eslint_result) do
-        "stdin:3:11: \"foo\" is defined but never used [Error/no-unused-vars]\n" \
-        "stdin:3:11: \"bar\" is defined but never used [Error/no-unused-vars]"
+        'stdin:3:11: "foo" is defined but never used ' \
+        "[Error/no-unused-vars]\n" \
+        'stdin:3:11: "bar" is defined but never used [Error/no-unused-vars]'
       end
 
       it 'removes all unused imports' do
@@ -2083,8 +2090,9 @@ foo
       EOS
 
       let(:eslint_result) do
-        "stdin:3:11: \"bar\" is defined but never used [Error/no-unused-vars]\n" \
-        "stdin:3:11: \"foo\" is not defined. [Error/no-undef]"
+        'stdin:3:11: "bar" is defined but never used ' \
+        "[Error/no-unused-vars]\n" \
+        'stdin:3:11: "foo" is not defined. [Error/no-undef]'
       end
 
       it 'removes the unused import and adds the missing one' do
@@ -2104,7 +2112,8 @@ bar
       EOS
 
       let(:eslint_result) do
-        "stdin:3:11: \"foo\" is defined but never used [Error/no-unused-vars]\n" \
+        'stdin:3:11: "foo" is defined but never used ' \
+        "[Error/no-unused-vars]\n" \
       end
 
       it 'removes that variable from the destructured list' do
@@ -2125,7 +2134,8 @@ bar
       EOS
 
       let(:eslint_result) do
-        "stdin:3:11: \"foo\" is defined but never used [Error/no-unused-vars]\n" \
+        'stdin:3:11: "foo" is defined but never used ' \
+        "[Error/no-unused-vars]\n" \
       end
 
       it 'removes the whole import' do

--- a/spec/import_js/mock_vim_buffer.rb
+++ b/spec/import_js/mock_vim_buffer.rb
@@ -23,7 +23,7 @@ class MockVimBuffer
   def count
     @buffer_lines.length
   end
-  alias_method :length, :count
+  alias length count
 
   # @param one_indexed_n [Number] line number
   # @return [String] a line from the buffer

--- a/spec/import_js/mock_vim_window.rb
+++ b/spec/import_js/mock_vim_window.rb
@@ -2,6 +2,7 @@ class MockVimWindow
   def cursor
     [1, 10]
   end
+
   def cursor=(*args)
   end
 end


### PR DESCRIPTION
We want to improve the code quality an consistency of this codebase, so
we are deciding to use rubocop. This commit fixes most of the things
that it was complaining about and adds a little conservative
configuration to get us started. There are still a number of errors that
it is complaining about that we still need to deal with, either by
fixing or adjusting configuration, and there might be other rubocop
rules that are disabled by default that we will want to enable, but this
seems like a good first pass.