### PR TITLE
Prevent preserving only whitespace at tops of files

### DIFF
--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -262,7 +262,13 @@ module ImportJS
         break
       end
 
-      imports_start_line_index
+      # We don't want to skip over blocks that are only whitespace
+      (0...imports_start_line_index).each do |line_index|
+        line = @editor.read_line(line_index + 1)
+        return imports_start_line_index unless line.strip.empty?
+      end
+
+      0
     end
 
     # @return [Hash]

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -261,6 +261,42 @@ foo
           end
         end
 
+        context 'when just an empty line is at the top' do
+          let(:text) { <<-EOS.rstrip }
+
+foo
+          EOS
+
+          it 'does not preserve the empty line' do
+            expect(subject).to eq(<<-EOS.strip)
+import foo from 'bar/foo';
+
+foo
+            EOS
+          end
+        end
+
+        context 'when an empty line precedes a comment' do
+          let(:text) { <<-EOS.rstrip }
+
+// One-line comment
+
+foo
+          EOS
+
+          it 'adds the import below' do
+            expect(subject).to eq(<<-EOS.rstrip)
+
+// One-line comment
+
+import foo from 'bar/foo';
+
+foo
+            EOS
+          end
+        end
+
+
         context 'when one-line comments with empty lines are at the top' do
           let(:text) { <<-EOS.strip }
 // One-line comment


### PR DESCRIPTION
I noticed that if I had only whitespace at the top of my file, it was
preserved after importing. I didn't like this very much, so I decided to
add some code and tests to avoid this situation.