### PR TITLE
Improve whitespace at top check

### DIFF
--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -246,11 +246,7 @@ module ImportJS
         if inside_multi_line_comment || line =~ REGEX_MULTI_LINE_COMMENT_START
           matched_non_whitespace_line = true
           imports_start_line_index = line_index + 1
-          inside_multi_line_comment = if line =~ REGEX_MULTI_LINE_COMMENT_END
-                                        false
-                                      else
-                                        true
-                                      end
+          inside_multi_line_comment = !(line =~ REGEX_MULTI_LINE_COMMENT_END)
           next
         end
 

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -234,6 +234,7 @@ module ImportJS
       end
     end
 
+    # @return [Number]
     def find_imports_start_line_index
       imports_start_line_index = 0
 

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -239,10 +239,12 @@ module ImportJS
 
       # Skip over things at the top, like "use strict" and comments.
       inside_multi_line_comment = false
+      matched_non_whitespace_line = false
       (0...@editor.count_lines).each do |line_index|
         line = @editor.read_line(line_index + 1)
 
         if inside_multi_line_comment || line =~ REGEX_MULTI_LINE_COMMENT_START
+          matched_non_whitespace_line = true
           imports_start_line_index = line_index + 1
           inside_multi_line_comment = if line =~ REGEX_MULTI_LINE_COMMENT_END
                                         false
@@ -252,9 +254,13 @@ module ImportJS
           next
         end
 
-        if line =~ REGEX_USE_STRICT ||
-           line =~ REGEX_SINGLE_LINE_COMMENT ||
-           line =~ REGEX_WHITESPACE_ONLY
+        if line =~ REGEX_USE_STRICT || line =~ REGEX_SINGLE_LINE_COMMENT
+          matched_non_whitespace_line = true
+          imports_start_line_index = line_index + 1
+          next
+        end
+
+        if line =~ REGEX_WHITESPACE_ONLY
           imports_start_line_index = line_index + 1
           next
         end
@@ -263,11 +269,7 @@ module ImportJS
       end
 
       # We don't want to skip over blocks that are only whitespace
-      (0...imports_start_line_index).each do |line_index|
-        line = @editor.read_line(line_index + 1)
-        return imports_start_line_index unless line.strip.empty?
-      end
-
+      return imports_start_line_index if matched_non_whitespace_line
       0
     end
 

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -190,10 +190,10 @@ module ImportJS
       imports.uniq!(&:to_normalized)
     end
 
-    # @param new_imports [Array<ImportJS::ImportStatement>]
+    # @param imports [Array<ImportJS::ImportStatement>]
     # @return [String]
-    def generate_import_strings(new_imports)
-      new_imports.map do |import|
+    def generate_import_strings(import_statements)
+      import_statements.map do |import|
         import.to_import_strings(@editor.max_line_length, @editor.tab)
       end.flatten.sort
     end


### PR DESCRIPTION
I wasn't very happy with my original implementation of this, since it
required reading editor lines twice. So, I decided to revamp it with a
different strategy. By adding a little bit of bookkeeping to the method,
we can avoid the second scan.