### PR TITLE
Break out `destructures` from `aliases`

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,29 +159,6 @@ those, you can add them to the `aliases` configuration.
 }
 ```
 
-If you have a library that expose a single object that has a bunch of objects
-on it that you want to use, you can list those in a `destructure` array inside
-the alias (which then has to be turned into an object):
-
-```json
-"aliases": {
-  "$": "third-party-libs/jquery",
-  "_": {
-    "path": "third-party-libs/underscore",
-    "destructure": ["memoize", "debounce"]
-  }
-}
-```
-
-Imports then use [ES6 Destructuring Assigment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment),
-e.g.
-
-```javascript
-const { memoize } = require('underscore');
-
-memoize(() => { foo() });
-```
-
 Aliases can be made dynamic by using the `{filename}` string. This part of the
 alias will be replaced by the name of the file you are currently editing.
 
@@ -198,6 +175,40 @@ will for a file `foo/bar.js` result in
 ```javascript
 import styles from './bar.scss';
 ```
+
+
+### `destructures`
+
+If you have a module that expose a single object that has a bunch of objects on
+it that you want to use, you can add those to a `destructures` configuration
+option.
+
+```json
+"destructures": {
+  "underscore": [
+    "omit",
+    "debounce"
+  ],
+  "lib/utils": [
+    "escape",
+    "hasKey"
+  ]
+}
+```
+
+Imports then use [ES6 Destructuring Assigment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment),
+e.g.
+
+```javascript
+const { memoize } = require('underscore');
+
+memoize(() => { foo() });
+```
+
+The key used to describe the destructures should be a valid import path. This
+can be e.g. the name of a package found under `node_modules`, a path to a
+module you created yourself without the `lookup_path` prefix, or a relative
+import path.
 
 ### `declaration_keyword`
 

--- a/lib/import_js/configuration.rb
+++ b/lib/import_js/configuration.rb
@@ -8,6 +8,7 @@ module ImportJS
   DEFAULT_CONFIG = {
     'aliases' => {},
     'declaration_keyword' => 'import',
+    'destructures' => {},
     'eslint_executable' => 'eslint',
     'excludes' => [],
     'ignore_package_prefixes' => [],
@@ -45,7 +46,7 @@ module ImportJS
     # @return [ImportJS::JSModule?]
     def resolve_alias(variable_name, path_to_current_file)
       path = get('aliases')[variable_name]
-      return resolve_destructured_alias(variable_name) unless path
+      return unless path
 
       path = path['path'] if path.is_a? Hash
 
@@ -56,12 +57,13 @@ module ImportJS
       ImportJS::JSModule.new(import_path: path)
     end
 
-    def resolve_destructured_alias(variable_name)
-      get('aliases').each do |_, path|
-        next if path.is_a? String
-        next unless (path['destructure'] || []).include?(variable_name)
+    # @param variable_name [String]
+    # @return [ImportJS::JSModule?]
+    def resolve_destructured(variable_name)
+      get('destructures').each do |import_path, destructures|
+        next unless destructures.include?(variable_name)
 
-        js_module = ImportJS::JSModule.new(import_path: path['path'])
+        js_module = ImportJS::JSModule.new(import_path: import_path)
         js_module.is_destructured = true
         return js_module
       end

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -320,6 +320,9 @@ module ImportJS
       alias_module = @config.resolve_alias(variable_name, path_to_current_file)
       return [alias_module] if alias_module
 
+      destructured_module = @config.resolve_destructured(variable_name)
+      return [destructured_module] if destructured_module
+
       formatted_var_name = formatted_to_regex(variable_name)
       egrep_command =
         "egrep -i \"(/|^)#{formatted_var_name}(/index)?(/package)?\.js.*\""

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -1201,18 +1201,41 @@ $
         end
       end
 
-      context 'alias with `var` and a destructure object' do
+      context 'with `destructure` object' do
+        let(:configuration) do
+          {
+            'destructures' => {
+              'lib/utils' => %w[
+                foo
+                bar
+              ],
+            },
+          }
+        end
+        let(:text) { 'foo' }
+        let(:word) { 'foo' }
+
+        it 'resolves that import in a destructured way' do
+          expect(subject).to eq(<<-EOS.strip)
+import { foo } from 'lib/utils';
+
+foo
+          EOS
+        end
+      end
+
+      context 'using `var`, `aliases` and a `destructure` object' do
         let(:configuration) do
           {
             'declaration_keyword' => 'var',
+            'destructures' => {
+              'underscore' => %w[
+                memoize
+                debounce
+              ],
+            },
             'aliases' => {
-              '_' => {
-                'path' => 'underscore',
-                'destructure' => %w[
-                  memoize
-                  debounce
-                ],
-              },
+              '_' => 'underscore',
             },
           }
         end
@@ -1350,18 +1373,18 @@ memoize
         end
       end
 
-      context 'alias with `import` and a destructure object' do
+      context 'alias with `import` and a `destructures` object' do
         let(:configuration) do
           {
             'declaration_keyword' => 'import',
+            'destructures' => {
+              'underscore' => %w[
+                memoize
+                debounce
+              ],
+            },
             'aliases' => {
-              '_' => {
-                'path' => 'underscore',
-                'destructure' => %w[
-                  memoize
-                  debounce
-                ],
-              },
+              '_' => 'underscore',
             },
           }
         end


### PR DESCRIPTION
Some of the destructures you use will need an alias, but not all.
Before this change, in order to add a destructure, you also needed to
add an alias. To make this process easier to understand and more
powerful, we've decided to break out destructures into its own thing.
Easier because you'll no longer see aliases being objects mixed with
aliases being strings. More powerful because it is now more obvious that
you can use destructures for non-package-dependencies (this was possible
before, but they were awkwardly placed under the `aliases`
configuration).

Fixes #135