### PR TITLE
Improve wording of destructures section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,9 @@ import styles from './bar.scss';
 
 ### `destructures`
 
-If you have a module that expose a single object that has a bunch of objects on
-it that you want to use, you can add those to a `destructures` configuration
+If you have a ES2015 module that exports multiple things (named exports), or a
+CommonJS module that exports an object with properties on it that you want to
+destructure when importing, you can add those to a `destructures` configuration
 option.
 
 ```json


### PR DESCRIPTION
ES6/ES2015 modules are treated differently than CommonJS modules, so I
wanted to clarify that in this bit of documentation. While thinking
about this, I realized that since we are trending ES2015-first (e.g.
defaulting `declaration_keyword` to `import`), that we should perhaps
rename `destructures` to `named_exports`, but I'll leave that for
another time.