### PR TITLE
Improve examples in destructures section

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,16 @@ option.
 }
 ```
 
-Imports then use [ES6 Destructuring Assigment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment),
+Imports that use the `import` declaration keyword then use [named imports syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import),
+e.g.
+
+```javascript
+import { memoize } from 'underscore';
+
+memoize(() => { foo() });
+```
+
+and imports that use `const`, `let`, or `var` use [ES2015 Destructuring Assigment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment),
 e.g.
 
 ```javascript


### PR DESCRIPTION
This example was CommonJS-first, and I decided to make it ES2015-first,
since that is the future. While I was at it, I changed a reference from
ES6 to ES2015, since that is what we use everywhere else in this
document.