### PR TITLE
Rename `destructures` to `named_exports`

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,15 +177,15 @@ import styles from './bar.scss';
 ```
 
 
-### `destructures`
+### `named_exports`
 
 If you have a ES2015 module that exports multiple things (named exports), or a
 CommonJS module that exports an object with properties on it that you want to
-destructure when importing, you can add those to a `destructures` configuration
+destructure when importing, you can add those to a `named_exports` configuration
 option.
 
 ```json
-"destructures": {
+"named_exports": {
   "underscore": [
     "omit",
     "debounce"
@@ -215,7 +215,7 @@ const { memoize } = require('underscore');
 memoize(() => { foo() });
 ```
 
-The key used to describe the destructures should be a valid import path. This
+The key used to describe the named exports should be a valid import path. This
 can be e.g. the name of a package found under `node_modules`, a path to a
 module you created yourself without the `lookup_path` prefix, or a relative
 import path.

--- a/lib/import_js/configuration.rb
+++ b/lib/import_js/configuration.rb
@@ -8,7 +8,7 @@ module ImportJS
   DEFAULT_CONFIG = {
     'aliases' => {},
     'declaration_keyword' => 'import',
-    'destructures' => {},
+    'named_exports' => {},
     'eslint_executable' => 'eslint',
     'excludes' => [],
     'ignore_package_prefixes' => [],
@@ -59,12 +59,12 @@ module ImportJS
 
     # @param variable_name [String]
     # @return [ImportJS::JSModule?]
-    def resolve_destructured(variable_name)
-      get('destructures').each do |import_path, destructures|
-        next unless destructures.include?(variable_name)
+    def resolve_named_exports(variable_name)
+      get('named_exports').each do |import_path, named_exports|
+        next unless named_exports.include?(variable_name)
 
         js_module = ImportJS::JSModule.new(import_path: import_path)
-        js_module.is_destructured = true
+        js_module.has_named_exports = true
         return js_module
       end
       nil

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -177,10 +177,10 @@ module ImportJS
           'declaration_keyword', from_file: js_module.file_path)
         import.import_function = @config.get(
           'import_function', from_file: js_module.file_path)
-        if js_module.is_destructured
-          import.inject_destructured_variable(variable_name)
+        if js_module.has_named_exports
+          import.inject_named_import(variable_name)
         else
-          import.set_default_variable(variable_name)
+          import.set_default_import(variable_name)
         end
       else
         imports.unshift(js_module.to_import_statement(variable_name, @config))
@@ -298,7 +298,7 @@ module ImportJS
         break unless import_statement
 
         if imports[import_statement.path]
-          # Import already exists, so this line is likely one of a destructuring
+          # Import already exists, so this line is likely one of a named imports
           # pair. Combine it into the same ImportStatement.
           imports[import_statement.path].merge(import_statement)
         else
@@ -320,8 +320,8 @@ module ImportJS
       alias_module = @config.resolve_alias(variable_name, path_to_current_file)
       return [alias_module] if alias_module
 
-      destructured_module = @config.resolve_destructured(variable_name)
-      return [destructured_module] if destructured_module
+      named_imports_module = @config.resolve_named_exports(variable_name)
+      return [named_imports_module] if named_imports_module
 
       formatted_var_name = formatted_to_regex(variable_name)
       egrep_command =
@@ -402,7 +402,7 @@ module ImportJS
       if js_modules.length == 1
         js_module = js_modules.first
         js_module_name = js_module.display_name
-        imported = if js_module.is_destructured
+        imported = if js_module.has_named_exports
                      "`#{variable_name}` from `#{js_module_name}`"
                    else
                      "`#{js_module_name}`"

--- a/lib/import_js/js_module.rb
+++ b/lib/import_js/js_module.rb
@@ -7,7 +7,7 @@ module ImportJS
     attr_accessor :lookup_path
     attr_accessor :file_path
     attr_accessor :main_file
-    attr_accessor :is_destructured
+    attr_accessor :has_named_exports
 
     # @param lookup_path [String] the lookup path in which this module was found
     # @param relative_file_path [String] a full path to the file, relative to
@@ -112,10 +112,10 @@ module ImportJS
     # @return [ImportJS::ImportStatement]
     def to_import_statement(variable_name, config)
       ImportJS::ImportStatement.new.tap do |statement|
-        if is_destructured
-          statement.inject_destructured_variable(variable_name)
+        if has_named_exports
+          statement.inject_named_import(variable_name)
         else
-          statement.default_variable = variable_name
+          statement.default_import = variable_name
         end
         statement.path = import_path
         statement.declaration_keyword = config.get('declaration_keyword',

--- a/spec/import_js/import_statement_spec.rb
+++ b/spec/import_js/import_statement_spec.rb
@@ -22,15 +22,15 @@ describe ImportJS::ImportStatement do
         end
       end
 
-      context 'and it has a destructured assignment' do
+      context 'and it uses named imports' do
         let(:string) { "import { foo } from 'foo';" }
 
         it 'returns a valid ImportStatement instance' do
           expect(subject.assignment).to eq('{ foo }')
           expect(subject.path).to eq('foo')
-          expect(subject.destructured?).to be_truthy
-          expect(subject.default_variable).to eq(nil)
-          expect(subject.destructured_variables).to eq(['foo'])
+          expect(subject.named_imports?).to be_truthy
+          expect(subject.default_import).to eq(nil)
+          expect(subject.named_imports).to eq(['foo'])
         end
 
         context 'and it has line breaks' do
@@ -39,22 +39,22 @@ describe ImportJS::ImportStatement do
           it 'returns a valid ImportStatement instance' do
             expect(subject.assignment).to eq("{\n  foo,\n  bar,\n}")
             expect(subject.path).to eq('foo')
-            expect(subject.destructured?).to be_truthy
-            expect(subject.default_variable).to eq(nil)
-            expect(subject.destructured_variables).to eq(%w[foo bar])
+            expect(subject.named_imports?).to be_truthy
+            expect(subject.default_import).to eq(nil)
+            expect(subject.named_imports).to eq(%w[foo bar])
           end
         end
       end
 
-      context 'and it has default and a destructured assignment' do
+      context 'and it has default and a named import' do
         let(:string) { "import foo, { bar } from 'foo';" }
 
         it 'returns a valid ImportStatement instance' do
           expect(subject.assignment).to eq('foo, { bar }')
           expect(subject.path).to eq('foo')
-          expect(subject.destructured?).to be_truthy
-          expect(subject.default_variable).to eq('foo')
-          expect(subject.destructured_variables).to eq(['bar'])
+          expect(subject.named_imports?).to be_truthy
+          expect(subject.default_import).to eq('foo')
+          expect(subject.named_imports).to eq(['bar'])
         end
 
         context 'and it has line breaks' do
@@ -63,9 +63,9 @@ describe ImportJS::ImportStatement do
           it 'returns a valid ImportStatement instance' do
             expect(subject.assignment).to eq("foo, {\n  bar,\n  baz,\n}")
             expect(subject.path).to eq('foo')
-            expect(subject.destructured?).to be_truthy
-            expect(subject.default_variable).to eq('foo')
-            expect(subject.destructured_variables).to eq(%w[bar baz])
+            expect(subject.named_imports?).to be_truthy
+            expect(subject.default_import).to eq('foo')
+            expect(subject.named_imports).to eq(%w[bar baz])
           end
         end
       end
@@ -85,8 +85,8 @@ describe ImportJS::ImportStatement do
           expect(subject.path).to eq('foo')
         end
 
-        it 'is not destructured' do
-          expect(subject.destructured?).to be_falsy
+        it 'is not named_imports?' do
+          expect(subject.named_imports?).to be_falsy
         end
       end
 
@@ -105,9 +105,9 @@ describe ImportJS::ImportStatement do
         it 'returns a valid ImportStatement instance' do
           expect(subject.assignment).to eq('{ foo }')
           expect(subject.path).to eq('foo')
-          expect(subject.destructured?).to be_truthy
-          expect(subject.default_variable).to eq(nil)
-          expect(subject.destructured_variables).to eq(['foo'])
+          expect(subject.named_imports?).to be_truthy
+          expect(subject.default_import).to eq(nil)
+          expect(subject.named_imports).to eq(['foo'])
         end
 
         context 'and it has line breaks' do
@@ -116,26 +116,26 @@ describe ImportJS::ImportStatement do
           it 'returns a valid ImportStatement instance' do
             expect(subject.assignment).to eq("{\n  foo,\n  bar,\n}")
             expect(subject.path).to eq('foo')
-            expect(subject.destructured?).to be_truthy
-            expect(subject.default_variable).to eq(nil)
-            expect(subject.destructured_variables).to eq(%w[foo bar])
+            expect(subject.named_imports?).to be_truthy
+            expect(subject.default_import).to eq(nil)
+            expect(subject.named_imports).to eq(%w[foo bar])
           end
         end
 
-        context 'injecting a new destructured variable' do
+        context 'injecting a new named import' do
           let(:injected_variable) { 'bar' }
           let(:statement) do
             statement = subject
-            statement.inject_destructured_variable(injected_variable)
+            statement.inject_named_import(injected_variable)
             statement
           end
 
-          it 'does not add a default_variable' do
-            expect(statement.default_variable).to eq(nil)
+          it 'does not add a default_import' do
+            expect(statement.default_import).to eq(nil)
           end
 
           it 'adds that variable and sorts the list' do
-            expect(statement.destructured_variables).to eq(%w[bar foo])
+            expect(statement.named_imports).to eq(%w[bar foo])
           end
 
           it 'can reconstruct using `to_import_strings`' do
@@ -148,12 +148,12 @@ describe ImportJS::ImportStatement do
           context 'injecting a variable that is already in the list' do
             let(:injected_variable) { 'foo' }
 
-            it 'does not add a default variable' do
-              expect(statement.default_variable).to eq(nil)
+            it 'does not add a default import' do
+              expect(statement.default_import).to eq(nil)
             end
 
             it 'does not add a duplicate' do
-              expect(statement.destructured_variables).to eq(['foo'])
+              expect(statement.named_imports).to eq(['foo'])
             end
           end
         end
@@ -169,96 +169,96 @@ describe ImportJS::ImportStatement do
     end
   end
 
-  describe '#destructured?' do
+  describe '#named_imports?' do
     let(:import_statement) { described_class.new }
-    let(:default_variable) { nil }
-    let(:destructured_variables) { nil }
+    let(:default_import) { nil }
+    let(:named_imports) { nil }
 
     before do
-      unless default_variable.nil?
-        import_statement.default_variable = default_variable
+      unless default_import.nil?
+        import_statement.default_import = default_import
       end
 
-      unless destructured_variables.nil?
-        import_statement.destructured_variables = destructured_variables
+      unless named_imports.nil?
+        import_statement.named_imports = named_imports
       end
     end
 
-    subject { import_statement.destructured? }
+    subject { import_statement.named_imports? }
 
-    context 'without a default variable or destructured variables' do
+    context 'without a default import or named imports' do
       it { should eq(false) }
     end
 
-    context 'with a default variable' do
-      let(:default_variable) { 'foo' }
+    context 'with a default import' do
+      let(:default_import) { 'foo' }
       it { should eq(false) }
 
-      context 'when default variable is removed' do
+      context 'when default import is removed' do
         before { import_statement.delete_variable('foo') }
         it { should eq(false) }
       end
     end
 
-    context 'with destructured variables' do
-      let(:destructured_variables) { ['foo'] }
+    context 'with named imports' do
+      let(:named_imports) { ['foo'] }
       it { should eq(true) }
 
-      context 'when destructured variables are removed' do
+      context 'when named imports are removed' do
         before { import_statement.delete_variable('foo') }
         it { should eq(false) }
       end
     end
 
-    context 'with an empty array of destructured variables' do
-      let(:destructured_variables) { [] }
+    context 'with an empty array of named imports' do
+      let(:named_imports) { [] }
       it { should eq(false) }
     end
   end
 
   describe '#empty?' do
     let(:import_statement) { described_class.new }
-    let(:default_variable) { nil }
-    let(:destructured_variables) { nil }
+    let(:default_import) { nil }
+    let(:named_imports) { nil }
 
     before do
-      unless default_variable.nil?
-        import_statement.default_variable = default_variable
+      unless default_import.nil?
+        import_statement.default_import = default_import
       end
 
-      unless destructured_variables.nil?
-        import_statement.destructured_variables = destructured_variables
+      unless named_imports.nil?
+        import_statement.named_imports = named_imports
       end
     end
 
     subject { import_statement.empty? }
 
-    context 'without a default variable or destructured variables' do
+    context 'without a default import or named imports' do
       it { should eq(true) }
     end
 
-    context 'with a default variable' do
-      let(:default_variable) { 'foo' }
+    context 'with a default import' do
+      let(:default_import) { 'foo' }
       it { should eq(false) }
 
-      context 'when default variable is removed' do
+      context 'when default import is removed' do
         before { import_statement.delete_variable('foo') }
         it { should eq(true) }
       end
     end
 
-    context 'with destructured variables' do
-      let(:destructured_variables) { ['foo'] }
+    context 'with named imports' do
+      let(:named_imports) { ['foo'] }
       it { should eq(false) }
 
-      context 'when destructured variables are removed' do
+      context 'when named imports are removed' do
         before { import_statement.delete_variable('foo') }
         it { should eq(true) }
       end
     end
 
-    context 'with an empty array of destructured variables' do
-      let(:destructured_variables) { [] }
+    context 'with an empty array of named imports' do
+      let(:named_imports) { [] }
       it { should eq(true) }
     end
   end
@@ -266,28 +266,26 @@ describe ImportJS::ImportStatement do
   describe '#merge' do
     let(:existing_import_statement) { described_class.new }
     let(:new_import_statement) { described_class.new }
-    let(:existing_default_variable) { nil }
-    let(:existing_destructured_variables) { nil }
-    let(:new_default_variable) { nil }
-    let(:new_destructured_variables) { nil }
+    let(:existing_default_import) { nil }
+    let(:existing_named_imports) { nil }
+    let(:new_default_import) { nil }
+    let(:new_named_imports) { nil }
 
     before do
-      unless existing_default_variable.nil?
-        existing_import_statement.default_variable = existing_default_variable
+      unless existing_default_import.nil?
+        existing_import_statement.default_import = existing_default_import
       end
 
-      unless existing_destructured_variables.nil?
-        existing_import_statement.destructured_variables =
-          existing_destructured_variables
+      unless existing_named_imports.nil?
+        existing_import_statement.named_imports = existing_named_imports
       end
 
-      unless new_default_variable.nil?
-        new_import_statement.default_variable = new_default_variable
+      unless new_default_import.nil?
+        new_import_statement.default_import = new_default_import
       end
 
-      unless new_destructured_variables.nil?
-        new_import_statement.destructured_variables =
-          new_destructured_variables
+      unless new_named_imports.nil?
+        new_import_statement.named_imports = new_named_imports
       end
     end
 
@@ -296,62 +294,62 @@ describe ImportJS::ImportStatement do
       existing_import_statement
     end
 
-    context 'without a new default variable' do
-      let(:existing_default_variable) { 'foo' }
+    context 'without a new default import' do
+      let(:existing_default_import) { 'foo' }
 
-      it 'uses the existing default variable' do
-        expect(subject.default_variable).to eq('foo')
+      it 'uses the existing default import' do
+        expect(subject.default_import).to eq('foo')
       end
     end
 
-    context 'without an existing default variable' do
-      let(:new_default_variable) { 'foo' }
+    context 'without an existing default import' do
+      let(:new_default_import) { 'foo' }
 
-      it 'uses the new default variable' do
-        expect(subject.default_variable).to eq('foo')
+      it 'uses the new default import' do
+        expect(subject.default_import).to eq('foo')
       end
     end
 
-    context 'with both default variables' do
-      let(:existing_default_variable) { 'foo' }
-      let(:new_default_variable) { 'bar' }
+    context 'with both default imports' do
+      let(:existing_default_import) { 'foo' }
+      let(:new_default_import) { 'bar' }
 
-      it 'uses the new default variable' do
-        expect(subject.default_variable).to eq('bar')
+      it 'uses the new default import' do
+        expect(subject.default_import).to eq('bar')
       end
     end
 
-    context 'without new destructured variables' do
-      let(:existing_destructured_variables) { ['foo'] }
+    context 'without new named imports' do
+      let(:existing_named_imports) { ['foo'] }
 
-      it 'uses the existing destructured variables' do
-        expect(subject.destructured_variables).to eq(['foo'])
+      it 'uses the existing named imports' do
+        expect(subject.named_imports).to eq(['foo'])
       end
     end
 
-    context 'without existing destructured variables' do
-      let(:new_destructured_variables) { ['foo'] }
+    context 'without existing named imports' do
+      let(:new_named_imports) { ['foo'] }
 
-      it 'uses the new destructured variables' do
-        expect(subject.destructured_variables).to eq(['foo'])
+      it 'uses the new named imports' do
+        expect(subject.named_imports).to eq(['foo'])
       end
     end
 
-    context 'with both destructured variables' do
-      let(:existing_destructured_variables) { ['foo'] }
-      let(:new_destructured_variables) { ['bar'] }
+    context 'with both named imports' do
+      let(:existing_named_imports) { ['foo'] }
+      let(:new_named_imports) { ['bar'] }
 
-      it 'uses the new destructured variables' do
-        expect(subject.destructured_variables).to eq(%w[bar foo])
+      it 'uses the new named imports' do
+        expect(subject.named_imports).to eq(%w[bar foo])
       end
     end
 
-    context 'when the new destructured variable is the same as the existing' do
-      let(:existing_destructured_variables) { ['foo'] }
-      let(:new_destructured_variables) { ['foo'] }
+    context 'when the new named import is the same as the existing' do
+      let(:existing_named_imports) { ['foo'] }
+      let(:new_named_imports) { ['foo'] }
 
       it 'does not duplicate' do
-        expect(subject.destructured_variables).to eq(['foo'])
+        expect(subject.named_imports).to eq(['foo'])
       end
     end
   end
@@ -360,20 +358,20 @@ describe ImportJS::ImportStatement do
     let(:import_statement) { described_class.new }
     let(:import_function) { 'require' }
     let(:path) { 'path' }
-    let(:default_variable) { nil }
-    let(:destructured_variables) { nil }
+    let(:default_import) { nil }
+    let(:named_imports) { nil }
     let(:max_line_length) { 80 }
     let(:tab) { '  ' }
 
     before do
       import_statement.path = path
 
-      unless default_variable.nil?
-        import_statement.default_variable = default_variable
+      unless default_import.nil?
+        import_statement.default_import = default_import
       end
 
-      unless destructured_variables.nil?
-        import_statement.destructured_variables = destructured_variables
+      unless named_imports.nil?
+        import_statement.named_imports = named_imports
       end
     end
 
@@ -386,8 +384,8 @@ describe ImportJS::ImportStatement do
     context 'with import declaration keyword' do
       let(:declaration_keyword) { 'import' }
 
-      context 'with a default variable' do
-        let(:default_variable) { 'foo' }
+      context 'with a default import' do
+        let(:default_import) { 'foo' }
         it { should eq(["import foo from 'path';"]) }
 
         context 'with `import_function`' do
@@ -398,24 +396,24 @@ describe ImportJS::ImportStatement do
         end
 
         context 'when longer than max line length' do
-          let(:default_variable) { 'ReallyReallyReallyReallyLong' }
+          let(:default_import) { 'ReallyReallyReallyReallyLong' }
           let(:path) { 'also_very_long_for_some_reason' }
           let(:max_line_length) { 50 }
-          it { should eq(["import #{default_variable} from\n  '#{path}';"]) }
+          it { should eq(["import #{default_import} from\n  '#{path}';"]) }
 
           context 'with different tab' do
             let(:tab) { "\t" }
-            it { should eq(["import #{default_variable} from\n\t'#{path}';"]) }
+            it { should eq(["import #{default_import} from\n\t'#{path}';"]) }
           end
         end
       end
 
-      context 'with destructured variables' do
-        let(:destructured_variables) { %w[foo bar] }
+      context 'with named imports' do
+        let(:named_imports) { %w[foo bar] }
         it { should eq(["import { foo, bar } from 'path';"]) }
 
         context 'when longer than max line length' do
-          let(:destructured_variables) { %w[foo bar baz fizz buzz] }
+          let(:named_imports) { %w[foo bar baz fizz buzz] }
           let(:path) { 'also_very_long_for_some_reason' }
           let(:max_line_length) { 50 }
           it do
@@ -429,13 +427,13 @@ describe ImportJS::ImportStatement do
         end
       end
 
-      context 'with default and destructured variables' do
-        let(:default_variable) { 'foo' }
-        let(:destructured_variables) { %w[bar baz] }
+      context 'with default and named imports' do
+        let(:default_import) { 'foo' }
+        let(:named_imports) { %w[bar baz] }
         it { should eq(["import foo, { bar, baz } from 'path';"]) }
 
         context 'when longer than max line length' do
-          let(:destructured_variables) { %w[bar baz fizz buzz] }
+          let(:named_imports) { %w[bar baz fizz buzz] }
           let(:path) { 'also_very_long_for_some_reason' }
           let(:max_line_length) { 50 }
           it do
@@ -453,8 +451,8 @@ describe ImportJS::ImportStatement do
     context 'with const declaration keyword' do
       let(:declaration_keyword) { 'const' }
 
-      context 'with a default variable' do
-        let(:default_variable) { 'foo' }
+      context 'with a default import' do
+        let(:default_import) { 'foo' }
         it { should eq(["const foo = require('path');"]) }
 
         context 'with `import_function`' do
@@ -463,24 +461,24 @@ describe ImportJS::ImportStatement do
         end
 
         context 'when longer than max line length' do
-          let(:default_variable) { 'ReallyReallyReallyReallyLong' }
+          let(:default_import) { 'ReallyReallyReallyReallyLong' }
           let(:path) { 'also_very_long_for_some_reason' }
           let(:max_line_length) { 50 }
           it do
-            should eq(["const #{default_variable} =\n  require('#{path}');"])
+            should eq(["const #{default_import} =\n  require('#{path}');"])
           end
 
           context 'with different tab' do
             let(:tab) { "\t" }
             it do
-              should eq(["const #{default_variable} =\n\trequire('#{path}');"])
+              should eq(["const #{default_import} =\n\trequire('#{path}');"])
             end
           end
         end
       end
 
-      context 'with destructured variables' do
-        let(:destructured_variables) { %w[foo bar] }
+      context 'with named imports' do
+        let(:named_imports) { %w[foo bar] }
         it { should eq(["const { foo, bar } = require('path');"]) }
 
         context 'with `import_function`' do
@@ -489,7 +487,7 @@ describe ImportJS::ImportStatement do
         end
 
         context 'when longer than max line length' do
-          let(:destructured_variables) { %w[foo bar baz fizz buzz] }
+          let(:named_imports) { %w[foo bar baz fizz buzz] }
           let(:path) { 'also_very_long_for_some_reason' }
           let(:max_line_length) { 50 }
           it do
@@ -503,9 +501,9 @@ describe ImportJS::ImportStatement do
         end
       end
 
-      context 'with default and destructured variables' do
-        let(:default_variable) { 'foo' }
-        let(:destructured_variables) { %w[bar baz] }
+      context 'with default and named imports' do
+        let(:default_import) { 'foo' }
+        let(:named_imports) { %w[bar baz] }
         it do
           should eq(
             [
@@ -528,7 +526,7 @@ describe ImportJS::ImportStatement do
         end
 
         context 'when longer than max line length' do
-          let(:destructured_variables) { %w[bar baz fizz buzz] }
+          let(:named_imports) { %w[bar baz fizz buzz] }
           let(:path) { 'also_very_long_for_some_reason' }
           let(:max_line_length) { 50 }
           it do

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -1201,10 +1201,10 @@ $
         end
       end
 
-      context 'with `destructure` object' do
+      context 'with `named_exports` object' do
         let(:configuration) do
           {
-            'destructures' => {
+            'named_exports' => {
               'lib/utils' => %w[
                 foo
                 bar
@@ -1215,7 +1215,7 @@ $
         let(:text) { 'foo' }
         let(:word) { 'foo' }
 
-        it 'resolves that import in a destructured way' do
+        it 'resolves that import using named imports' do
           expect(subject).to eq(<<-EOS.strip)
 import { foo } from 'lib/utils';
 
@@ -1224,11 +1224,11 @@ foo
         end
       end
 
-      context 'using `var`, `aliases` and a `destructure` object' do
+      context 'using `var`, `aliases` and a `named_exports` object' do
         let(:configuration) do
           {
             'declaration_keyword' => 'var',
-            'destructures' => {
+            'named_exports' => {
               'underscore' => %w[
                 memoize
                 debounce
@@ -1250,7 +1250,7 @@ _
         EOS
         end
 
-        context 'when a destructured import exists for the same module' do
+        context 'when a named import exists for the same module' do
           let(:text) { <<-EOS.strip }
 var { memoize } = require('underscore');
 
@@ -1267,11 +1267,11 @@ _
           end
         end
 
-        context 'when importing a destructured object' do
+        context 'when importing a named export' do
           let(:text) { 'memoize' }
           let(:word) { 'memoize' }
 
-          it 'resolves that import in a destructured way' do
+          it 'resolves that import using destructuring' do
             expect(subject).to eq(<<-EOS.strip)
 var { memoize } = require('underscore');
 
@@ -1373,11 +1373,11 @@ memoize
         end
       end
 
-      context 'alias with `import` and a `destructures` object' do
+      context 'alias with `import` and a `named_exports` object' do
         let(:configuration) do
           {
             'declaration_keyword' => 'import',
-            'destructures' => {
+            'named_exports' => {
               'underscore' => %w[
                 memoize
                 debounce
@@ -1391,7 +1391,7 @@ memoize
         let(:text) { '_' }
         let(:word) { '_' }
 
-        it 'resolves the main alias without destructuring' do
+        it 'resolves the main alias without a named import' do
           expect(subject).to eq(<<-EOS.strip)
 import _ from 'underscore';
 
@@ -1399,7 +1399,7 @@ _
         EOS
         end
 
-        context 'when a destructured import exists for the same module' do
+        context 'when a named import exists for the same module' do
           let(:text) { <<-EOS.strip }
 import { memoize } from 'underscore';
 
@@ -1415,11 +1415,11 @@ _
           end
         end
 
-        context 'when importing a destructured object' do
+        context 'when importing a named export' do
           let(:text) { 'memoize' }
           let(:word) { 'memoize' }
 
-          it 'resolves that import in a destructured way' do
+          it 'uses a named import' do
             expect(subject).to eq(<<-EOS.strip)
 import { memoize } from 'underscore';
 
@@ -1446,14 +1446,14 @@ memoize
             end
           end
 
-          context 'when other destructured imports exist for the same module' do
+          context 'when other named imports exist for the same module' do
             let(:text) { <<-EOS.strip }
 import { xyz, debounce } from 'underscore';
 
 memoize
             EOS
 
-            it 'combines the destructured import and sorts items' do
+            it 'combines the named import and sorts items' do
               expect(subject).to eq(<<-EOS.strip)
 import { debounce, memoize, xyz } from 'underscore';
 
@@ -1461,7 +1461,7 @@ memoize
               EOS
             end
 
-            context 'when the module is already in the destructured object' do
+            context 'when the module is already in the named imports' do
               let(:text) { <<-EOS.strip }
 import { debounce, memoize, xyz } from 'underscore';
 
@@ -1485,7 +1485,7 @@ import _ from 'underscore';
 memoize
             EOS
 
-            it 'adds the destructured import' do
+            it 'adds the named import' do
               expect(subject).to eq(<<-EOS.strip)
 import _, { memoize } from 'underscore';
 
@@ -1493,7 +1493,7 @@ memoize
               EOS
             end
 
-            context 'when the module is already in the destructured object' do
+            context 'when the module is already in the named import' do
               let(:text) { <<-EOS.strip }
 import _, { memoize } from 'underscore';
 
@@ -2188,7 +2188,7 @@ foo
       end
     end
 
-    context 'when a destructured import has an unused variable' do
+    context 'when a named import has an unused variable' do
       let(:text) { <<-EOS.strip }
 import { bar, foo } from 'baz';
 
@@ -2200,7 +2200,7 @@ bar
         "[Error/no-unused-vars]\n" \
       end
 
-      it 'removes that variable from the destructured list' do
+      it 'removes that variable from the named imports list' do
         expect(subject).to eq(<<-EOS.strip)
 import { bar } from 'baz';
 
@@ -2209,7 +2209,7 @@ bar
       end
     end
 
-    context 'when the last import is removed from a destructured import' do
+    context 'when the last import is removed from a named import' do
       let(:text) { <<-EOS.strip }
 import bar from 'bar';
 import { foo } from 'baz';


### PR DESCRIPTION
ES2015 modules can have default exports and named exports (along with
default imports and named imports). In keeping with our trend of
ES2015-first (e.g. defaulting declaration_keyword to 'import'), I'm
renaming the `destructures` configuration key to `named_exports`, and
adjusting the names we use in the code to match.

This is a little bit of a blurry line, since the rules are actually
different between ES2015 named exports and CommonJS destructuring, and
if you are using ES2015 `import` on a CommonJS module that has things
defined in the `named_exports` configuration, that doesn't actually make
them named exports and according to the spec shouldn't actually work.
You might have the inverse problem if not using `import` and requiring
an ES2015 module. In practice, this likely depends on what tool you use
to build your modules and the compatibility layer they've decided to
cook up for ESM/CommonJS interoperability.

Since I think this issue exists for either name we choose, I think we
should go with the one that is most consistent with our approach, which
is `named_exports`. Alternatively, we could use both `named_exports` and
`destructures`, but I'm not sure that's really worth it.

Fixes #161