### PR TITLE
Check version used against `minimum_version` config

### DIFF
--- a/lib/import_js.rb
+++ b/lib/import_js.rb
@@ -10,6 +10,10 @@ module ImportJS
   class FindError < StandardError
     # Error thrown when the find command fails
   end
+
+  class ClientTooOldError < StandardError
+    # Error thrwon when the client is too old to handle the config
+  end
 end
 
 require_relative 'import_js/command_line_editor'

--- a/lib/import_js/configuration.rb
+++ b/lib/import_js/configuration.rb
@@ -15,6 +15,7 @@ module ImportJS
     'import_dev_dependencies' => false,
     'import_function' => 'require',
     'lookup_paths' => ['.'],
+    'minimum_version' => '0.0.0',
     'strip_file_extensions' => ['.js', '.jsx'],
     'strip_from_path' => nil,
     'use_relative_paths' => false,
@@ -28,6 +29,8 @@ module ImportJS
       user_config = load_config(CONFIG_FILE)
       @configs.concat([user_config].flatten.reverse) if user_config
       @configs << DEFAULT_CONFIG
+
+      check_current_version!
     end
 
     # @return [Object] a configuration value
@@ -98,6 +101,18 @@ module ImportJS
       path = path.sub(/^#{Regexp.escape(Dir.pwd)}/, '.')
       path = "./#{path}" unless path.start_with?('.')
       path
+    end
+
+    # Checks that the current version is bigger than the `minimum_version`
+    # defined in config. Raises an error if it doesn't match.
+    def check_current_version!
+      minimum_version = get('minimum_version')
+      return if Gem::Dependency.new('', ">= #{minimum_version}")
+                               .match?('', ImportJS::VERSION)
+
+      fail ImportJS::ClientTooOldError,
+           'The .importjs.json file you are using requires version ' \
+           "#{get('minimum_version')}. You are using #{ImportJS::VERSION}."
     end
   end
 end


### PR DESCRIPTION
If the format of the configuration file changes in a way that requires
people to upgrade their editor plugins, we will now help people
understand that they need to upgrade by showing an error message.

The current version of import-js will be checked against a
`minimum_version` configuration. If the version requirement isn't
fulfilled, an error is thrown. I'm using the built-in `Gem::Dependency`
class to check versions. Right now I'm prepending `>=` to the min
version before checking. If we find that this is too simple, we can
choose to expand the `minimum_version` to a `match_version` (or
something) and allow people to use a gem-dependency-style matching
string instead, e.g. `~> 1.2.3`, `> 2.0`.

Fixes #153