### PR TITLE
Make goto resolution work for aliases that reference packages

### DIFF
--- a/lib/import_js/configuration.rb
+++ b/lib/import_js/configuration.rb
@@ -57,7 +57,7 @@ module ImportJS
         path = path.sub(/\{filename\}/,
                         File.basename(path_to_current_file, '.*'))
       end
-      ImportJS::JSModule.new(import_path: path)
+      JSModule.new(import_path: path)
     end
 
     # @param variable_name [String]
@@ -66,7 +66,7 @@ module ImportJS
       get('named_exports').each do |import_path, named_exports|
         next unless named_exports.include?(variable_name)
 
-        js_module = ImportJS::JSModule.new(import_path: import_path)
+        js_module = JSModule.new(import_path: import_path)
         js_module.has_named_exports = true
         return js_module
       end
@@ -108,11 +108,11 @@ module ImportJS
     def check_current_version!
       minimum_version = get('minimum_version')
       return if Gem::Dependency.new('', ">= #{minimum_version}")
-                               .match?('', ImportJS::VERSION)
+                               .match?('', VERSION)
 
-      fail ImportJS::ClientTooOldError,
+      fail ClientTooOldError,
            'The .importjs.json file you are using requires version ' \
-           "#{get('minimum_version')}. You are using #{ImportJS::VERSION}."
+           "#{get('minimum_version')}. You are using #{VERSION}."
     end
   end
 end

--- a/lib/import_js/emacs_editor.rb
+++ b/lib/import_js/emacs_editor.rb
@@ -16,13 +16,13 @@ module ImportJS
 
           case command
           when 'import'
-            ImportJS::Importer.new(self).import
+            Importer.new(self).import
             write_file
             puts 'import:success'
           when 'goto'
-            ImportJS::Importer.new(self).goto
+            Importer.new(self).goto
           when 'fix'
-            ImportJS::Importer.new(self).fix_imports
+            Importer.new(self).fix_imports
             write_file
             puts 'import:success'
           else

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -45,13 +45,18 @@ module ImportJS
       time do
         js_modules = find_js_modules(variable_name)
       end
+
+      # If no JS modules are found in this project, there is nothing to go to,
+      # so we return early.
       return if js_modules.empty?
 
       js_module = resolve_goto_module(js_modules, variable_name)
-      if js_module
-        @editor.open_file(js_module.open_file_path(
-                            @editor.path_to_current_file))
-      end
+
+      # If the current word is not mappable to one of the JS modules that we
+      # found, then we have nothing to go to, so we return early.
+      return unless js_module
+
+      @editor.open_file(js_module.open_file_path(@editor.path_to_current_file))
     end
 
     REGEX_ESLINT_RESULT = /
@@ -438,7 +443,7 @@ module ImportJS
         end
       end
 
-      # fall back to asking the user to resolve the ambiguity
+      # Fall back to asking the user to resolve the ambiguity
       resolve_one_js_module(js_modules, variable_name)
     end
 

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -46,15 +46,19 @@ module ImportJS
         js_modules = find_js_modules(variable_name)
       end
 
-      # If no JS modules are found in this project, there is nothing to go to,
-      # so we return early.
-      return if js_modules.empty?
+      if js_modules.empty?
+        # No JS modules are found for the variable, so there is nothing to go to
+        # and we return early.
+        return message("No modules were found for `#{variable_name}`")
+      end
 
       js_module = resolve_goto_module(js_modules, variable_name)
 
-      # If the current word is not mappable to one of the JS modules that we
-      # found, then we have nothing to go to, so we return early.
-      return unless js_module
+      unless js_module
+        # The current word is not mappable to one of the JS modules that we
+        # found, then we have nothing to go to, so we return early.
+        return message("Could not resolve a module for `#{variable_name}`")
+      end
 
       @editor.open_file(js_module.open_file_path(@editor.path_to_current_file))
     end

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -16,7 +16,7 @@ module ImportJS
     # Finds variable under the cursor to import. By default, this is bound to
     # `<Leader>j`.
     def import
-      @config = ImportJS::Configuration.new(@editor.path_to_current_file)
+      reload_config
       variable_name = @editor.current_word
       if variable_name.empty?
         message(<<-EOS.split.join(' '))
@@ -39,7 +39,7 @@ module ImportJS
     end
 
     def goto
-      @config = ImportJS::Configuration.new(@editor.path_to_current_file)
+      reload_config
       js_modules = []
       variable_name = @editor.current_word
       time do
@@ -75,7 +75,7 @@ module ImportJS
 
     # Removes unused imports and adds imports for undefined variables
     def fix_imports
-      @config = ImportJS::Configuration.new(@editor.path_to_current_file)
+      reload_config
       eslint_result = run_eslint_command
 
       unused_variables = []
@@ -113,6 +113,13 @@ module ImportJS
     end
 
     private
+
+    # The configuration is relative to the current file, so we need to make sure
+    # that we are operating with the appropriate configuration when we perform
+    # certain actions.
+    def reload_config
+      @config = ImportJS::Configuration.new(@editor.path_to_current_file)
+    end
 
     def message(str)
       @editor.message("ImportJS: #{str}")

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -56,7 +56,8 @@ module ImportJS
 
       unless js_module
         # The current word is not mappable to one of the JS modules that we
-        # found, then we have nothing to go to, so we return early.
+        # found. This can happen if the user does not select one from the list.
+        # We have nothing to go to, so we return early.
         return message("Could not resolve a module for `#{variable_name}`")
       end
 

--- a/lib/import_js/js_module.rb
+++ b/lib/import_js/js_module.rb
@@ -52,12 +52,9 @@ module ImportJS
     # @return [String, String]
     def self.resolve_import_path_and_main(file_path, strip_file_extensions)
       if file_path.end_with? '/package.json'
-        begin
-          file_contents = File.read(file_path)
-        rescue Errno::ENOENT
-          # The package.json does not exist, so we just return early.
-          return [nil, nil]
-        end
+        return [nil, nil] unless File.exist?(file_path)
+
+        file_contents = File.read(file_path)
         return [nil, nil] unless file_contents
 
         main_file = JSON.parse(file_contents)['main']

--- a/lib/import_js/js_module.rb
+++ b/lib/import_js/js_module.rb
@@ -111,11 +111,22 @@ module ImportJS
     # @return [String]
     def open_file_path(path_to_current_file)
       if file_path
+        # There is a file_path. This happens for JSModules that are not aliases.
         return file_path unless file_path.end_with?('/package.json')
+
+        # The file_path points to a package.json file, so we want to look in
+        # that package.json file for a `main` configuration value and open that
+        # file instead.
         return file_path.sub(/package\.json$/, main_file)
       end
 
+      # There is no file_path. This likely means that we are working with an
+      # alias, so we want to expand it to a full path if we can.
+
       if import_path.start_with?('.')
+        # The import path in the alias starts with a ".", which means that it is
+        # relative to the current file. In order to open this file, we need to
+        # expand it to a full path.
         return File.expand_path(import_path, File.dirname(path_to_current_file))
       end
 

--- a/lib/import_js/js_module.rb
+++ b/lib/import_js/js_module.rb
@@ -110,27 +110,27 @@ module ImportJS
     # @param path_to_current_file [String]
     # @return [String]
     def open_file_path(path_to_current_file)
-      if file_path
+      if @file_path
         # There is a file_path. This happens for JSModules that are not aliases.
-        return file_path unless file_path.end_with?('/package.json')
+        return @file_path unless @file_path.end_with?('/package.json')
 
         # The file_path points to a package.json file, so we want to look in
         # that package.json file for a `main` configuration value and open that
         # file instead.
-        return file_path.sub(/package\.json$/, main_file)
+        return @file_path.sub(/package\.json$/, main_file)
       end
 
       # There is no file_path. This likely means that we are working with an
       # alias, so we want to expand it to a full path if we can.
 
-      if import_path.start_with?('.')
+      if @import_path.start_with?('.')
         # The import path in the alias starts with a ".", which means that it is
         # relative to the current file. In order to open this file, we need to
         # expand it to a full path.
-        return File.expand_path(import_path, File.dirname(path_to_current_file))
+        return File.expand_path(@import_path, File.dirname(path_to_current_file))
       end
 
-      import_path
+      @import_path
     end
 
     # @param variable_name [String]

--- a/lib/import_js/js_module.rb
+++ b/lib/import_js/js_module.rb
@@ -55,7 +55,7 @@ module ImportJS
         return [nil, nil] unless File.exist?(file_path)
 
         file_contents = File.read(file_path)
-        return [nil, nil] unless file_contents
+        return [nil, nil] if file_contents.strip.empty?
 
         main_file = JSON.parse(file_contents)['main']
         return [nil, nil] unless main_file

--- a/lib/import_js/js_module.rb
+++ b/lib/import_js/js_module.rb
@@ -137,7 +137,7 @@ module ImportJS
     # @param config [ImportJS::Configuration]
     # @return [ImportJS::ImportStatement]
     def to_import_statement(variable_name, config)
-      ImportJS::ImportStatement.new.tap do |statement|
+      ImportStatement.new.tap do |statement|
         if has_named_exports
           statement.inject_named_import(variable_name)
         else

--- a/lib/import_js/js_module.rb
+++ b/lib/import_js/js_module.rb
@@ -160,9 +160,9 @@ module ImportJS
 
       # This is likely an alias that points to a package, so let's try to find
       # its main file from its package.json file.
-      file_path = "node_modules/#{import_path}/package.json"
+      file_path = "node_modules/#{@import_path}/package.json"
       _, main = self.class.resolve_import_path_and_main(file_path, [])
-      return "node_modules/#{import_path}/#{main}" if main
+      return "node_modules/#{@import_path}/#{main}" if main
 
       @import_path
     end

--- a/lib/import_js/js_module.rb
+++ b/lib/import_js/js_module.rb
@@ -110,10 +110,10 @@ module ImportJS
     # @param path_to_current_file [String]
     # @return [String]
     def open_file_path(path_to_current_file)
-      if file_path && file_path.end_with?('/package.json')
+      if file_path
+        return file_path unless file_path.end_with?('/package.json')
         return file_path.sub(/package\.json$/, main_file)
       end
-      return file_path if file_path
 
       if import_path.start_with?('.')
         return File.expand_path(import_path, File.dirname(path_to_current_file))

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -630,7 +630,11 @@ FooIO
         before do
           allow_any_instance_of(ImportJS::Configuration)
             .to receive(:package_dependencies).and_return(package_dependencies)
+          allow(File).to receive(:exist?).and_call_original
           package_dependencies.each do |dep|
+            allow(File).to receive(:exist?)
+              .with("node_modules/#{dep}/package.json")
+              .and_return(true)
             allow(File).to receive(:read)
               .with("node_modules/#{dep}/package.json")
               .and_return('{ "main": "bar.jsx" }')
@@ -2081,6 +2085,10 @@ var a = <span/>;
         before do
           allow_any_instance_of(ImportJS::Configuration)
             .to receive(:package_dependencies).and_return(['react'])
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?)
+            .with('node_modules/react/package.json')
+            .and_return(true)
           allow(File).to receive(:read)
             .with('node_modules/react/package.json')
             .and_return('{ "main": "index.jsx" }')
@@ -2250,6 +2258,10 @@ bar
       before do
         allow_any_instance_of(ImportJS::Configuration)
           .to receive(:package_dependencies).and_return(['foo'])
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?)
+          .with('node_modules/foo/package.json')
+          .and_return(true)
         allow(File).to receive(:read)
           .with('node_modules/foo/package.json')
           .and_return('{ "main": "bar.jsx" }')
@@ -2284,6 +2296,10 @@ bar
         let(:aliaz) { 'stylez' }
 
         before do
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?)
+            .with("node_modules/#{aliaz}/package.json")
+            .and_return(true)
           allow(File).to receive(:read)
             .with("node_modules/#{aliaz}/package.json")
             .and_return('{ "main": "bar.jsx" }')

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -2283,11 +2283,16 @@ bar
       context 'to an absolute resource' do
         let(:aliaz) { 'stylez' }
 
-        it 'opens the alias path' do
-          # This won't work in most cases, but this is all the information we
-          # have available
-          expect_any_instance_of(ImportJS::VIMEditor).to receive(
-            :open_file).with('stylez')
+        before do
+          allow(File).to receive(:read)
+            .with("node_modules/#{aliaz}/package.json")
+            .and_return('{ "main": "bar.jsx" }')
+        end
+
+        it 'opens the alias main file' do
+          expect_any_instance_of(ImportJS::VIMEditor)
+            .to receive(:open_file)
+            .with("node_modules/#{aliaz}/bar.jsx")
           subject
         end
       end

--- a/spec/import_js/js_module_spec.rb
+++ b/spec/import_js/js_module_spec.rb
@@ -319,6 +319,7 @@ describe ImportJS::JSModule do
 
       context 'when the file has JSON but no main file' do
         before do
+          allow(File).to receive(:exist?).and_call_original
           allow(File).to receive(:exist?).with(file_path).and_return(true)
           allow(File).to receive(:read).with(file_path)
             .and_return('{}')
@@ -326,6 +327,30 @@ describe ImportJS::JSModule do
 
         it 'returns nils' do
           expect(subject).to eq([nil, nil])
+        end
+
+        context 'when there is an index.js' do
+          before do
+            allow(File).to receive(:exist?)
+              .with("#{package_path}/index.js")
+              .and_return(true)
+          end
+
+          it 'resolves to index.js' do
+            expect(subject).to eq([package_path, 'index.js'])
+          end
+        end
+
+        context 'when there is an index.jsx' do
+          before do
+            allow(File).to receive(:exist?)
+              .with("#{package_path}/index.jsx")
+              .and_return(true)
+          end
+
+          it 'resolves to index.jsx' do
+            expect(subject).to eq([package_path, 'index.jsx'])
+          end
         end
       end
 

--- a/spec/import_js/js_module_spec.rb
+++ b/spec/import_js/js_module_spec.rb
@@ -297,7 +297,7 @@ describe ImportJS::JSModule do
     end
 
     context 'when the file path ends with /package.json' do
-      let(:package_path) { 'node_modues/foo' }
+      let(:package_path) { 'node_modules/foo' }
       let(:file_path) { "#{package_path}/package.json" }
 
       context 'when the file path does not exist' do

--- a/spec/import_js/js_module_spec.rb
+++ b/spec/import_js/js_module_spec.rb
@@ -340,6 +340,50 @@ describe ImportJS::JSModule do
         it 'returns the package path and the main file' do
           expect(subject).to eq([package_path, main_file])
         end
+
+        context 'when main is a directory' do
+          let(:main_file) { 'bar' }
+          let(:main_path) { "#{package_path}/#{main_file}" }
+
+          before do
+            allow(File).to receive(:exist?).with(main_path).and_return(true)
+            allow(File).to receive(:directory?).with(main_path).and_return(true)
+          end
+
+          context 'and the main directory has an index.js file' do
+            let(:main_index) { 'index.js' }
+            let(:main_index_path) { "#{main_path}/#{main_index}" }
+
+            before do
+              allow(File).to receive(:exist?)
+                .with("#{main_path}/index.jsx").and_return(false)
+              allow(File).to receive(:exist?)
+                .with(main_index_path).and_return(true)
+            end
+
+            it 'returns the package path and main/index.js' do
+              expect(subject)
+                .to eq([package_path, "#{main_file}/#{main_index}"])
+            end
+          end
+
+          context 'and the main directory has an index.jsx file' do
+            let(:main_index) { 'index.jsx' }
+            let(:main_index_path) { "#{main_path}/#{main_index}" }
+
+            before do
+              allow(File).to receive(:exist?)
+                .with("#{main_path}/index.js").and_return(false)
+              allow(File).to receive(:exist?)
+                .with(main_index_path).and_return(true)
+            end
+
+            it 'returns the package path and main/index.jsx' do
+              expect(subject)
+                .to eq([package_path, "#{main_file}/#{main_index}"])
+            end
+          end
+        end
       end
     end
 

--- a/spec/import_js/js_module_spec.rb
+++ b/spec/import_js/js_module_spec.rb
@@ -210,6 +210,9 @@ describe ImportJS::JSModule do
         let(:relative_file_path) { 'node_modules/foo/package.json' }
         let(:main_file) { 'index.jsx' }
         before do
+          allow(File).to receive(:exist?)
+            .with(relative_file_path)
+            .and_return(true)
           allow(File).to receive(:read)
             .with(relative_file_path)
             .and_return("{ \"main\": \"#{main_file}\" }")
@@ -260,6 +263,9 @@ describe ImportJS::JSModule do
         context 'when it is an alias of a package' do
           let(:main_file) { 'index.jsx' }
           before do
+            allow(File).to receive(:exist?)
+              .with("node_modules/#{import_path}/package.json")
+              .and_return(true)
             allow(File).to receive(:read)
               .with("node_modules/#{import_path}/package.json")
               .and_return("{ \"main\": \"#{main_file}\" }")

--- a/spec/import_js/js_module_spec.rb
+++ b/spec/import_js/js_module_spec.rb
@@ -257,9 +257,25 @@ describe ImportJS::JSModule do
       context 'when the import path does not have any dots at the beginning' do
         let(:import_path) { 'my-package' }
 
-        it 'does nothing to the path' do
-          expect(subject.open_file_path(path_to_current_file))
-            .to eq(import_path)
+        context 'when it is an alias of a package' do
+          let(:main_file) { 'index.jsx' }
+          before do
+            allow(File).to receive(:read)
+              .with("node_modules/#{import_path}/package.json")
+              .and_return("{ \"main\": \"#{main_file}\" }")
+          end
+
+          it 'gives the main path found in the package.json' do
+            expect(subject.open_file_path(path_to_current_file))
+              .to eq("node_modules/#{import_path}/#{main_file}")
+          end
+        end
+
+        context 'when it is not an alias of a package' do
+          it 'does nothing to the path' do
+            expect(subject.open_file_path(path_to_current_file))
+              .to eq(import_path)
+          end
         end
       end
     end


### PR DESCRIPTION
If I have an alias like

    "Foo": "my-foo-package"

when I use the goto feature on `Foo`, I am taken to an empty file at
`my-foo-package` instead of taken to the package. This commit aims to
improve this by looking up the package's main file.

In testing this, I noticed that package.json files can reference a
directory as the main file, in which case it should resolve to index.js
in that directory.

Fixes #172. Fixes #175.