### PR TITLE
Remove `let` as valid declaration_keyword choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ import { memoize } from 'underscore';
 memoize(() => { foo() });
 ```
 
-and imports that use `const`, `let`, or `var` use [ES2015 Destructuring Assigment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment),
+and imports that use `const` or `var` use [ES2015 Destructuring
+Assigment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment),
 e.g.
 
 ```javascript
@@ -230,8 +231,8 @@ syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statem
 import Foo from 'foo';
 ```
 
-If you aren't ready for ES2015 yet, you have the option to use `var`, `let`, or
-`const` instead.
+If you aren't ready for ES2015 yet, you have the option to use `var` or `const`
+instead.
 
 ```json
 "declaration_keyword": "const"
@@ -241,7 +242,6 @@ In such case, your import statements will look something like this:
 
 ```js
 var Foo = require('foo'); // "declaration_keyword": "var"
-let Foo = require('foo'); // "declaration_keyword": "let"
 const Foo = require('foo'); // "declaration_keyword": "const"
 ```
 
@@ -258,7 +258,7 @@ importing. By default, only modules listed under `dependencies` and
 
 ### `import_function`
 
-*Note: this only applies if you are using `var`, `let`, or `const` as
+*Note: this only applies if you are using `var` or `const` as
 `declaration_keyword`.*
 
 The default value for this configuration option is `"require"`, which is [the

--- a/lib/import_js/import_statement.rb
+++ b/lib/import_js/import_statement.rb
@@ -1,7 +1,7 @@
 module ImportJS
   # Class that represents an import statement, e.g.
   # `const foo = require('foo');`
-  # `let foo = myCustomRequire('foo');`
+  # `var foo = myCustomRequire('foo');`
   # `import foo from 'foo';`
   class ImportStatement
     REGEX_CONST_LET_VAR = /
@@ -50,7 +50,7 @@ module ImportJS
 
     # @param string [String] a possible import statement, e.g.
     #   `const foo = require('foo');`
-    #   `let foo = myCustomRequire('foo');`
+    #   `var foo = myCustomRequire('foo');`
     #   `import foo from 'foo';`
     # @return [ImportJS::ImportStatement?] a parsed statement, or nil if the
     #   string can't be parsed
@@ -138,7 +138,7 @@ module ImportJS
         else
           [default_import_string(max_line_length, tab)]
         end
-      else # const/let/var
+      else # const/var
         strings = []
 
         if default_import

--- a/spec/import_js/configuration_spec.rb
+++ b/spec/import_js/configuration_spec.rb
@@ -67,7 +67,7 @@ describe ImportJS::Configuration do
         let(:configuration) do
           [
             {
-              'declaration_keyword' => 'let',
+              'declaration_keyword' => 'const',
               'import_function' => 'foobar',
             },
             {
@@ -95,7 +95,7 @@ describe ImportJS::Configuration do
           let(:path_to_current_file) { 'foo/far/gar.js' }
 
           it 'uses the global configuration' do
-            expect(subject.get('declaration_keyword')).to eq('let')
+            expect(subject.get('declaration_keyword')).to eq('const')
           end
         end
 

--- a/spec/import_js/import_statement_spec.rb
+++ b/spec/import_js/import_statement_spec.rb
@@ -391,7 +391,7 @@ describe ImportJS::ImportStatement do
         context 'with `import_function`' do
           let(:import_function) { 'myCustomRequire' }
 
-          # `import_function` only applies to const/let/var
+          # `import_function` only applies to const/var
           it { should eq(["import foo from 'path';"]) }
         end
 

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -1323,7 +1323,7 @@ memoize
 
           context 'with other imports' do
             let(:text) { <<-EOS.strip }
-let bar = require('foo/bar');
+const bar = require('foo/bar');
 var { xyz } = require('alphabet');
 
 memoize
@@ -1331,7 +1331,7 @@ memoize
 
             it 'places the import at the right place' do
               expect(subject).to eq(<<-EOS.strip)
-let bar = require('foo/bar');
+const bar = require('foo/bar');
 var { memoize } = require('underscore');
 var { xyz } = require('alphabet');
 


### PR DESCRIPTION
I can't think of a scenario where someone would want to actually use let
as declaration_keyword. Although supporting it is very easy for us in
code, I think that having the option available creates unnecessary
confusion for people getting this set up.

In practice, we still need to support matching `let` in our regexes
because people can type whatever they want and we don't want to fall
over if they decide to use `let` for some reason. So, this mostly
removes its usage from documentation and comments.

Fixes #163