### PR TITLE
Add dispatch settings to .projections.json

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -1,10 +1,12 @@
 {
   "lib/import_js/*.rb": {
     "alternate": "spec/import_js/{}_spec.rb",
-    "type": "source"
+    "type": "source",
+    "dispatch": "rspec spec/import_js/{}_spec.rb"
   },
   "spec/import_js/*_spec.rb": {
     "alternate": "lib/import_js/{}.rb",
-    "type": "test"
+    "type": "test",
+    "dispatch": "rspec {file}"
   }
 }


### PR DESCRIPTION
This tells plugins like vim-dispatch what to do by default when dispatch
is called without arguments, making it easier to run tests on the
current file.