### PR TITLE
Default Vim's max_line_length to 80

### DIFF
--- a/lib/import_js/vim_editor.rb
+++ b/lib/import_js/vim_editor.rb
@@ -113,7 +113,9 @@ module ImportJS
     # Get the preferred max length of a line
     # @return [Number?]
     def max_line_length
-      get_number('&textwidth')
+      length = get_number('&textwidth')
+      return length unless length == 0
+      80
     end
 
     # @return [String] shiftwidth number of spaces if expandtab is not set,

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -1111,6 +1111,46 @@ foo
           EOS
         end
       end
+
+      context "when Vim's textwidth is 0" do
+        # This is the default, unconfigured behavior for Vim
+        before(:each) do
+          allow_any_instance_of(ImportJS::VIMEditor)
+            .to receive(:get_number)
+            .with('&textwidth')
+            .and_return(0)
+        end
+
+        context 'when lines are shorter than 80 characters' do
+          let(:existing_files) { ['bar/foo.jsx'] }
+
+          it 'does not wrap them' do
+            expect(subject).to eq(<<-EOS.strip)
+import foo from 'bar/foo';
+
+foo
+            EOS
+          end
+        end
+
+        context 'when lines are longer than 80 characters' do
+          let(:existing_files) do
+            [
+              'foo/bar/foo/bar/foo/bar/foo/bar/foo/bar/foo/bar/foo/bar/foo/bar/foo/bar/foo.jsx',
+            ]
+          end
+
+          it 'wraps them' do
+            expect(subject).to eq(<<-EOS.strip)
+import foo from
+	'foo/bar/foo/bar/foo/bar/foo/bar/foo/bar/foo/bar/foo/bar/foo/bar/foo/bar/foo';
+
+foo
+            EOS
+          end
+        end
+      end
+
     end
 
     context 'configuration' do


### PR DESCRIPTION
By default, Vim will run with a textwidth of 0. With this setting,
everything ends up getting wrapped, which is not very good. To make this
better, I am defaulting the max_line_length to 80 if we encounter a 0.

In the long run, I think we should move this back into configuration,
since teams use a variety of editors which may not be configured the
same way.

Fixes #187