### PR TITLE
Allow command-line tool to overwrite file contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,19 +407,20 @@ editor](SUBLIME.md) uses.
 
 ```bash
 ⨠ import-js --help
-usage: import-js [options]
-    -w, --word     A word/variable to import
-    --goto         Instead of importing, just print the path to a module
-    --selections   A list of resolved selections, e.g. Foo:0,Bar:1
-    --filename     A path to the file currently being processed. If
-                   contents are passed in via stdin, this is only used
-                   as a way to make sure that the right configuration is
-                   used. If nothing is passed in via stdin, the contents
-                   of this file will be used.
-    --overwrite    Overwrite the file with the result after
-                   importing(the default behavior is to print to stdout)
-    -v, --version  print the current version
-    -h, --help     prints help
+Usage: import-js [<path-to-file>] [options] ...
+    -w, --word         A word/variable to import
+    --goto             Instead of importing, just print the path to a module
+    --selections       A list of resolved selections, e.g. Foo:0,Bar:1
+    --stdin-file-path  A path to the file whose content is being passed in as stdin.
+                       This is used as a way to make sure that the right configuration
+                       is applied.
+    --overwrite        Overwrite the file with the result after importing (the
+                       default behavior is to print to stdout). This only applies
+                       if you are passing in a file (<path- to-file>) as the first
+                       positional argument.
+    --filename         (deprecated) Alias for --stdin-file-path
+    -v, --version      Prints the current version
+    -h, --help         Prints help
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -399,6 +399,29 @@ When using `applies_from` only a subset of configurations are supported:
 - `strip_from_path`
 - `use_relative_paths`
 
+## Command-line tool
+
+Import-js comes with a handy command-line tool that can help you perform
+importing outside of an editor. Under the hood, this is what the [Sublime
+editor](SUBLIME.md) uses.
+
+```bash
+⨠ import-js --help
+usage: import-js [options]
+    -w, --word     A word/variable to import
+    --goto         Instead of importing, just print the path to a module
+    --selections   A list of resolved selections, e.g. Foo:0,Bar:1
+    --filename     A path to the file currently being processed. If
+                   contents are passed in via stdin, this is only used
+                   as a way to make sure that the right configuration is
+                   used. If nothing is passed in via stdin, the contents
+                   of this file will be used.
+    --overwrite    Overwrite the file with the result after
+                   importing(the default behavior is to print to stdout)
+    -v, --version  print the current version
+    -h, --help     prints help
+```
+
 ## Contributing
 
 See the

--- a/bin/import-js
+++ b/bin/import-js
@@ -9,7 +9,7 @@ opts = Slop.parse do |o|
   o.string '-w', '--word', 'A word/variable to import'
   o.bool '--goto', 'Instead of importing, just print the path to a module'
   o.array '--selections', 'A list of resolved selections, e.g. Foo:0,Bar:1'
-  o.string '--filename',
+  o.string '--stdin-file-path',
            'A path to the file whose content is being passed in as stdin. ' \
            'This is used as a way to make sure that the right configuration ' \
            'is applied.'
@@ -17,6 +17,7 @@ opts = Slop.parse do |o|
          'Overwrite the file with the result after importing (the default ' \
          'behavior is to print to stdout). This only applies if you are ' \
          'passing in a file (<path-to-file>) as the first postitional argument.'
+  o.string '--filename', '(deprecated) alias for --stdin-file-path'
 
   o.on '-v', '--version', 'print the current version' do
     puts ImportJS::VERSION
@@ -28,7 +29,7 @@ opts = Slop.parse do |o|
   end
 end
 
-path_to_file = opts.arguments[0]
+path_to_file = opts.arguments[0] || opts['stdin-file-path'] || opts[:filename]
 
 file_contents = if STDIN.tty?
                   unless path_to_file
@@ -36,7 +37,6 @@ file_contents = if STDIN.tty?
                     puts opts
                     exit 1
                   end
-                  opts[:filename] = path_to_file
                   File.read(path_to_file).split("\n")
                 else
                   STDIN.read.split("\n")
@@ -50,7 +50,8 @@ if opts[:selections]
   end]
 end
 
-editor = ImportJS::CommandLineEditor.new(file_contents, opts)
+editor = ImportJS::CommandLineEditor.new(
+  file_contents, opts.to_hash.merge(path_to_file: path_to_file))
 importer = ImportJS::Importer.new(editor)
 if opts.goto?
   importer.goto

--- a/bin/import-js
+++ b/bin/import-js
@@ -5,18 +5,18 @@ require 'slop'
 require 'json'
 
 opts = Slop.parse do |o|
+  o.banner = 'usage: import-js [<path-to-file>] [options] ...'
   o.string '-w', '--word', 'A word/variable to import'
   o.bool '--goto', 'Instead of importing, just print the path to a module'
   o.array '--selections', 'A list of resolved selections, e.g. Foo:0,Bar:1'
   o.string '--filename',
-           'A path to the file currently being processed. ' \
-           'If contents are passed in via stdin, this is only used as a way ' \
-           'to make sure that the right configuration is used. ' \
-           'If nothing is passed in via stdin, the contents of this file ' \
-           'will be used.'
+           'A path to the file whose content is being passed in as stdin. ' \
+           'This is used as a way to make sure that the right configuration ' \
+           'is applied.'
   o.bool '--overwrite',
-         'Overwrite the file with the result after importing' \
-         '(the default behavior is to print to stdout)'
+         'Overwrite the file with the result after importing (the default ' \
+         'behavior is to print to stdout). This only applies if you are ' \
+         'passing in a file (<path-to-file>) as the first postitional argument.'
 
   o.on '-v', '--version', 'print the current version' do
     puts ImportJS::VERSION
@@ -28,9 +28,16 @@ opts = Slop.parse do |o|
   end
 end
 
+path_to_file = opts.arguments[0]
+
 file_contents = if STDIN.tty?
-                  fail 'Missing filename' unless opts[:filename]
-                  File.read(opts[:filename]).split("\n")
+                  unless path_to_file
+                    puts 'Error: missing <path-to-file>'
+                    puts opts
+                    exit 1
+                  end
+                  opts[:filename] = path_to_file
+                  File.read(path_to_file).split("\n")
                 else
                   STDIN.read.split("\n")
                 end
@@ -57,7 +64,7 @@ if opts.goto?
   # Print the path to the module to go to
   puts editor.goto
 elsif opts[:overwrite]
-  File.open(opts[:filename], 'w') do |f|
+  File.open(path_to_file, 'w') do |f|
     f.write editor.current_file_content
   end
 else

--- a/bin/import-js
+++ b/bin/import-js
@@ -5,11 +5,19 @@ require 'slop'
 require 'json'
 
 opts = Slop.parse do |o|
-  o.string '-w', '--word', 'a word/variable to import'
-  o.bool '--goto', 'instead of importing, just print the path to a module'
-  o.array '--selections', 'a list of resolved selections, e.g. Foo:0,Bar:1'
+  o.string '-w', '--word', 'A word/variable to import'
+  o.bool '--goto', 'Instead of importing, just print the path to a module'
+  o.array '--selections', 'A list of resolved selections, e.g. Foo:0,Bar:1'
   o.string '--filename',
-           'a path to the file which contents are being passed in as stdin'
+           'A path to the file currently being processed. ' \
+           'If contents are passed in via stdin, this is only used as a way ' \
+           'to make sure that the right configuration is used. ' \
+           'If nothing is passed in via stdin, the contents of this file ' \
+           'will be used.'
+  o.bool '--overwrite',
+         'Overwrite the file with the result after importing' \
+         '(the default behavior is to print to stdout)'
+
   o.on '-v', '--version', 'print the current version' do
     puts ImportJS::VERSION
     exit
@@ -20,7 +28,12 @@ opts = Slop.parse do |o|
   end
 end
 
-file_contents = STDIN.read.split("\n")
+file_contents = if STDIN.tty?
+                  fail 'Missing filename' unless opts[:filename]
+                  File.read(opts[:filename]).split("\n")
+                else
+                  STDIN.read.split("\n")
+                end
 
 if opts[:selections]
   # Convert array of string tuples to hash, `word` => `selectedIndex`
@@ -43,6 +56,10 @@ end
 if opts.goto?
   # Print the path to the module to go to
   puts editor.goto
+elsif opts[:overwrite]
+  File.open(opts[:filename], 'w') do |f|
+    f.write editor.current_file_content
+  end
 else
   # Print resulting file to stdout
   puts editor.current_file_content

--- a/bin/import-js
+++ b/bin/import-js
@@ -5,7 +5,7 @@ require 'slop'
 require 'json'
 
 opts = Slop.parse do |o|
-  o.banner = 'usage: import-js [<path-to-file>] [options] ...'
+  o.banner = 'Usage: import-js [<path-to-file>] [options] ...'
   o.string '-w', '--word', 'A word/variable to import'
   o.bool '--goto', 'Instead of importing, just print the path to a module'
   o.array '--selections', 'A list of resolved selections, e.g. Foo:0,Bar:1'
@@ -16,14 +16,14 @@ opts = Slop.parse do |o|
   o.bool '--overwrite',
          'Overwrite the file with the result after importing (the default ' \
          'behavior is to print to stdout). This only applies if you are ' \
-         'passing in a file (<path-to-file>) as the first postitional argument.'
-  o.string '--filename', '(deprecated) alias for --stdin-file-path'
+         'passing in a file (<path-to-file>) as the first positional argument.'
+  o.string '--filename', '(deprecated) Alias for --stdin-file-path'
 
-  o.on '-v', '--version', 'print the current version' do
+  o.on '-v', '--version', 'Prints the current version' do
     puts ImportJS::VERSION
     exit
   end
-  o.on '-h', '--help', 'prints help' do
+  o.on '-h', '--help', 'Prints help' do
     puts o
     exit
   end

--- a/import-js.py
+++ b/import-js.py
@@ -46,7 +46,7 @@ class ImportJsCommand(sublime_plugin.TextCommand):
       command.append('--selections')
       command.append(','.join(args.get('selections')))
 
-    command.append('--filename')
+    command.append('--stdin-file-path')
     command.append(self.view.file_name())
 
     print(command)

--- a/lib/import_js/command_line_editor.rb
+++ b/lib/import_js/command_line_editor.rb
@@ -7,7 +7,7 @@ module ImportJS
       @ask_for_selections = []
       @selections = opts[:selections] unless opts[:selections].empty?
       @word = opts[:word]
-      @filename = opts[:filename]
+      @path_to_file = opts[:path_to_file]
     end
 
     # @return [String]
@@ -17,7 +17,7 @@ module ImportJS
 
     # @return [String?]
     def path_to_current_file
-      @filename
+      @path_to_file
     end
 
     # @param file_path [String]


### PR DESCRIPTION
We want to support batch-updating multiple files via the `import-js`
command. An important part of that is to overwrite the file with the new
content. This commit takes care of that, and at the same time adds
support for passing in only a --filename and no content via stdin.

This takes us one step closer to supporting the usecase described in
[#173].