### PR TITLE
Add `rewrite_imports` command

### DIFF
--- a/bin/import-js
+++ b/bin/import-js
@@ -18,6 +18,8 @@ opts = Slop.parse do |o|
          'behavior is to print to stdout). This only applies if you are ' \
          'passing in a file (<path-to-file>) as the first positional argument.'
   o.string '--filename', '(deprecated) Alias for --stdin-file-path'
+  o.bool '--rewrite',
+         'Rewrite all current imports instead of importing anything.'
 
   o.on '-v', '--version', 'Prints the current version' do
     puts ImportJS::VERSION
@@ -57,6 +59,8 @@ if opts.goto?
   importer.goto
 elsif opts[:word]
   importer.import
+elsif opts[:rewrite]
+  importer.rewrite_imports
 else
   importer.fix_imports
 end

--- a/bin/import-js
+++ b/bin/import-js
@@ -70,7 +70,7 @@ if opts.goto?
   puts editor.goto
 elsif opts[:overwrite]
   File.open(path_to_file, 'w') do |f|
-    f.write editor.current_file_content
+    f.write editor.current_file_content + "\n"
   end
 else
   # Print resulting file to stdout

--- a/bin/import-js
+++ b/bin/import-js
@@ -19,7 +19,8 @@ opts = Slop.parse do |o|
          'passing in a file (<path-to-file>) as the first positional argument.'
   o.string '--filename', '(deprecated) Alias for --stdin-file-path'
   o.bool '--rewrite',
-         'Rewrite all current imports instead of importing anything.'
+         'Rewrite all current imports to match Import-JS configuration. ' \
+         'This does not add missing imports or remove unused imports.'
 
   o.on '-v', '--version', 'Prints the current version' do
     puts ImportJS::VERSION

--- a/lib/import_js/import_statement.rb
+++ b/lib/import_js/import_statement.rb
@@ -116,6 +116,12 @@ module ImportJS
       default_import.nil? && !named_imports?
     end
 
+    # @return [Boolean] true if this instance was created through parsing an
+    #   existing import and it hasn't been altered since it was created.
+    def parsed_and_untouched?
+      !original_import_string.nil?
+    end
+
     # @return [Array] an array that can be used in `uniq!` to dedupe equal
     #   statements, e.g.
     #   `const foo = require('foo');`

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -46,7 +46,8 @@ module ImportJS
         js_modules = find_js_modules(variable_name)
       end
 
-      js_module = resolve_goto_module(js_modules, variable_name)
+      js_module = resolve_module_using_current_imports(
+        js_modules, variable_name)
 
       unless js_module
         # The current word is not mappable to one of the JS modules that we
@@ -118,7 +119,8 @@ module ImportJS
       old_imports[:imports].each do |import|
         variables = [import.default_import].concat(import.named_imports || [])
         variables.compact.each do |variable|
-          js_module = resolve_goto_module(find_js_modules(variable), variable)
+          js_module = resolve_module_using_current_imports(
+            find_js_modules(variable), variable)
           inject_js_module(variable, js_module, new_imports) if js_module
         end
       end
@@ -461,7 +463,7 @@ module ImportJS
     # @param js_modules [Array]
     # @param variable_name [String]
     # @return [ImportJS::JSModule]
-    def resolve_goto_module(js_modules, variable_name)
+    def resolve_module_using_current_imports(js_modules, variable_name)
       return js_modules.first if js_modules.length == 1
 
       # Look at the current imports and grab what is already imported for the

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -126,7 +126,13 @@ module ImportJS
       end
 
       # There's a chance we have duplicate imports (can happen when switching
-      # declaration_keyword for instance).
+      # declaration_keyword for instance). By first sorting imports so that new
+      # ones are first, then removing duplicates, we guarantee that we delete
+      # the old ones that are now redundant.
+      new_imports = new_imports.partition do |import|
+        !import.parsed_and_untouched?
+      end.flatten
+
       new_imports.uniq! do |import|
         [import.default_import].concat(import.named_imports || []).compact
       end

--- a/spec/import_js/import_statement_spec.rb
+++ b/spec/import_js/import_statement_spec.rb
@@ -216,6 +216,25 @@ describe ImportJS::ImportStatement do
     end
   end
 
+  describe '#parsed_and_untouched?' do
+    subject { statement.parsed_and_untouched? }
+
+    context 'for parsed statements' do
+      let(:statement) { described_class.parse("const foo = require('foo');") }
+      it { should be_truthy }
+
+      context 'when touched' do
+        before { statement.set_default_import('Foo') }
+        it { should be_falsy }
+      end
+    end
+
+    context 'for statements created through the constructor' do
+      let(:statement) { described_class.new }
+      it { should be_falsy }
+    end
+  end
+
   describe '#empty?' do
     let(:import_statement) { described_class.new }
     let(:default_import) { nil }

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -2231,6 +2231,10 @@ bar
 
       allow_any_instance_of(ImportJS::Configuration)
         .to receive(:get).with('named_exports').and_return('bar' => ['foo'])
+
+      allow_any_instance_of(ImportJS::VIMEditor)
+        .to receive(:path_to_current_file)
+        .and_return("#{@tmp_dir}/app/bilbo/frodo.js")
     end
 
     subject do
@@ -2281,10 +2285,7 @@ bar
       EOS
 
       context 'and we are turning relative paths off' do
-        before do
-          allow_any_instance_of(ImportJS::Configuration)
-            .to receive(:use_relative_paths).and_return(false)
-        end
+        let(:configuration) { { 'use_relative_paths' => false } }
 
         it 'changes to absolute paths' do
           expect(subject).to eq(<<-EOS.strip)
@@ -2306,10 +2307,7 @@ bar
       EOS
 
       context 'and we are turning relative paths on' do
-        before do
-          allow_any_instance_of(ImportJS::Configuration)
-            .to receive(:use_relative_paths).and_return(true)
-        end
+        let(:configuration) { { 'use_relative_paths' => true } }
 
         it 'changes to relative paths' do
           expect(subject).to eq(<<-EOS.strip)


### PR DESCRIPTION
Invoked by using the `--rewrite` flag in the CLI tool, this command will
rewrite all existing import statements. This is useful if you want to
batch-update many files with a change to `declaration_keyword`,
`use_relative_paths`, `import_function` etc.

I'm not documenting this feature too much at this point. There are
a few tricky edge-cases that I still haven't figured out how to deal
with:

 - Resolving ambiguous imports - we currently just print some info to
   the JSON object output to stderr.
 - Switching to relative imports doesn't currently work - we need to
   figure out a better way to get rid of duplicates in the resulting
   import statements than just using `uniq`.
 - Current imports that we can't map to a js module - this can happen if
   you have manually entered import statements. Right now we just keep
   them as-is.

[Fixes #173]