### PR TITLE
Prevent using installed gem in vim plugin

### DIFF
--- a/autoload/importjs.vim
+++ b/autoload/importjs.vim
@@ -24,7 +24,7 @@ endfun
 
 ruby << EOF
   begin
-    require 'import_js'
+    require 'vim_import_js'
     $import_js = ImportJS::Importer.new
   rescue LoadError
     load_path_modified = false

--- a/lib/vim_import_js.rb
+++ b/lib/vim_import_js.rb
@@ -1,0 +1,4 @@
+# This is a proxy file for ./import_js.rb. Vim needs it so that we can prevent
+# any installed import_js gems from being loaded before the files in the local
+# filesystem.
+require_relative './import_js'


### PR DESCRIPTION
If you had the import_js gem installed, the vim plugin would pick up
that instead of the local files in the lib folder. This was annoying,
and took me quite a while to track down.

By introducing a "proxy" file to avoid having to "require 'import_js'"
directly, we can work around that.

[Fixes #122]