### PR TITLE
Vim: Map commands only in JavaScript files

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -1,0 +1,11 @@
+if !hasmapto(':ImportJSImport<CR>') && maparg('<Leader>j', 'n') == ''
+  silent! nnoremap <buffer> <unique> <silent> <Leader>j :ImportJSImport<CR>
+endif
+
+if !hasmapto(':ImportJSFixImports<CR>') && maparg('<Leader>i', 'n') == ''
+  silent! nnoremap <buffer> <unique> <silent> <Leader>i :ImportJSFixImports<CR>
+endif
+
+if !hasmapto(':ImportJSGoTo<CR>') && maparg('<Leader>g', 'n') == ''
+  silent! nnoremap <buffer> <unique> <silent> <Leader>g :ImportJSGoTo<CR>
+endif

--- a/plugin/import-js.vim
+++ b/plugin/import-js.vim
@@ -7,15 +7,3 @@ command ImportJSImport call importjs#ImportJSImport()
 command ImportJSGoTo call importjs#ImportJSGoTo()
 command ImportJSRemoveUnusedImports call importjs#ImportJSRemoveUnusedImports()
 command ImportJSFixImports call importjs#ImportJSFixImports()
-
-if !hasmapto(':ImportJSImport<CR>') && maparg('<Leader>j', 'n') == ''
-  silent! nnoremap <unique> <silent> <Leader>j :ImportJSImport<CR>
-endif
-
-if !hasmapto(':ImportJSFixImports<CR>') && maparg('<Leader>i', 'n') == ''
-  silent! nnoremap <unique> <silent> <Leader>i :ImportJSFixImports<CR>
-endif
-
-if !hasmapto(':ImportJSGoTo<CR>') && maparg('<Leader>g', 'n') == ''
-  silent! nnoremap <unique> <silent> <Leader>g :ImportJSGoTo<CR>
-endif


### PR DESCRIPTION
Vim has decent filetype detection built into it, which enables files in
the special ftplugin directory to be applied to files of specific types.
I think it makes the most sense for us to put our mappings in a
ftplugin/javascript.vim file so that they are only set up when in
JavaScript files.

In making this change, I also had to add the <buffer> argument to the
mappings, which makes the mapping effective in the current buffer only.
This will prevent the mapping from leaking out into other types of files
after visiting a JavaScript file.