### PR TITLE
Put imports for package-local modules in right group

### DIFF
--- a/lib/import_js/import_statements.rb
+++ b/lib/import_js/import_statements.rb
@@ -166,7 +166,11 @@ module ImportJS
     # @param package_dependencies [Array<String>]
     # @return [String] 'package, 'non-relative', 'relative'
     def import_statement_path_type(import_statement, package_dependencies)
-      path = import_statement.path
+      # If there is a slash in the path, remove that and everything after it.
+      # This is so that imports for modules inside package dependencies end up
+      # in the right group (PATH_TYPE_PACKAGE).
+      path = import_statement.path.sub(%r{\A(.*?)/.*\Z}, '\1')
+
       return PATH_TYPE_RELATIVE if path.start_with?('.')
       return PATH_TYPE_PACKAGE if package_dependencies.include?(path)
       PATH_TYPE_NON_RELATIVE

--- a/spec/import_js/import_statements_spec.rb
+++ b/spec/import_js/import_statements_spec.rb
@@ -139,6 +139,44 @@ describe ImportJS::ImportStatements do
         ]
       )
     end
+
+    context 'when one statement is a package dependency' do
+      let(:second_import_statement) do
+        ImportJS::ImportStatement.parse("import bar from 'bar';")
+      end
+
+      before do
+        allow_any_instance_of(ImportJS::Configuration)
+          .to receive(:package_dependencies)
+          .and_return(['bar'])
+      end
+
+      it 'gives the two statements in different groups' do
+        expect(subject.to_a).to eq(
+          [
+            "import bar from 'bar';",
+            '',
+            "import foo from 'foo';",
+          ]
+        )
+      end
+
+      context 'when importing a package-local module' do
+        let(:second_import_statement) do
+          ImportJS::ImportStatement.parse("import bar from 'bar/too/far';")
+        end
+
+        it 'gives the two statements in different groups' do
+          expect(subject.to_a).to eq(
+            [
+              "import bar from 'bar/too/far';",
+              '',
+              "import foo from 'foo';",
+            ]
+          )
+        end
+      end
+    end
   end
 
   context 'when pushed import statements of all different kinds' do


### PR DESCRIPTION
Me and @lencioni have both come across examples where we import a
package-local module (through an alias). These used to end up in the
wrong import group, because of how we were matching them against package
dependencies. Here's an example from the Brigade codebase:

const Nprogress = require('nprogress/nprogress');

By stripping out everything after and including the first slash before
matching against package dependencies, they are back in the right group
again.

[Fixes #208]