### PR TITLE
Clean out whitespace when removing the last import

### DIFF
--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -247,9 +247,9 @@ module ImportJS
 
       if import_strings.empty? &&
          @editor.read_line(old_imports_range.first).empty?
-        # We have no imports to write back to the editor, and they used to be at
-        # the top. To avoid leaving whitespace behind, we'll look at what's at
-        # the top and
+        # We have no newlines to write back to the file. Clearing out potential
+        # whitespace where the imports used to be leaves the file in a better
+        # state.
         @editor.delete_line(old_imports_range.first)
         return
       end

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -244,6 +244,16 @@ module ImportJS
       old_imports_range.each do
         @editor.delete_line(old_imports_range.first)
       end
+
+      if import_strings.empty? &&
+         @editor.read_line(old_imports_range.first).empty?
+        # We have no imports to write back to the editor, and they used to be at
+        # the top. To avoid leaving whitespace behind, we'll look at what's at
+        # the top and
+        @editor.delete_line(old_imports_range.first)
+        return
+      end
+
       import_strings.reverse_each do |import_string|
         # We need to add each line individually because the Vim buffer will
         # convert newline characters to `~@`.

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -2193,6 +2193,28 @@ bar
 bar
             EOS
           end
+
+          context 'with whitespace after the comment' do
+            let(:text) { <<-EOS.strip }
+// I'm a comment
+
+import foo from 'bar/foo';
+
+bar
+            EOS
+
+            let(:eslint_result) do
+              'stdin:3:7: "foo" is defined but never used [Error/no-unused-vars]'
+            end
+
+            it 'removes that import and leaves one newline' do
+              expect(subject).to eq(<<-EOS.strip)
+// I'm a comment
+
+bar
+              EOS
+            end
+          end
         end
 
         context 'and there is no previous whitespace' do

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -2145,21 +2145,68 @@ var a = <span/>;
 
     context 'when one unused import exists' do
       let(:text) { <<-EOS.strip }
-import bar from 'foo/bar';
 import foo from 'bar/foo';
+import zar from 'foo/zar';
 
 bar
       EOS
       let(:eslint_result) do
-        'stdin:2:7: "foo" is defined but never used [Error/no-unused-vars]'
+        'stdin:1:7: "foo" is defined but never used [Error/no-unused-vars]'
       end
 
       it 'removes that import' do
         expect(subject).to eq(<<-EOS.strip)
-import bar from 'foo/bar';
+import zar from 'foo/zar';
 
 bar
         EOS
+      end
+
+      context 'when that import is the last one' do
+        let(:text) { <<-EOS.strip }
+import foo from 'bar/foo';
+
+bar
+        EOS
+
+        it 'removes that import and leaves no whitespace' do
+          expect(subject).to eq(<<-EOS.strip)
+bar
+          EOS
+        end
+
+        context 'and there is a comment above' do
+          let(:text) { <<-EOS.strip }
+// I'm a comment
+import foo from 'bar/foo';
+
+bar
+          EOS
+
+          let(:eslint_result) do
+            'stdin:2:7: "foo" is defined but never used [Error/no-unused-vars]'
+          end
+
+          it 'removes that import and leaves no whitespace' do
+            expect(subject).to eq(<<-EOS.strip)
+// I'm a comment
+bar
+            EOS
+          end
+        end
+
+        context 'and there is no previous whitespace' do
+          let(:text) { <<-EOS.strip }
+import foo from 'bar/foo';
+bar
+          EOS
+
+          it 'removes that import and leaves no whitespace' do
+            expect(subject).to eq(<<-EOS.strip)
+bar
+            EOS
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Normally, we want a blank line after the block of imports. When removing
the last import however, we would leave an unwanted blank line behind.

[Fixes #204]