### PR TITLE
Allow grouping to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ the cursor on a variable and hit `<leader>g` (Vim), `(M-x) import-js-goto`
 
 - Only files ending in .js\* are considered when importing
 - As part of resolving imports, all imports will be sorted and placed into
-  groups (package dependencies first, then one or more groups with internal
-  imports).
+  groups. *Grouping can be disabled, see the `group_imports` configuration
+  option.*
 - The core of the plugin is written in Ruby. If you are using Vim, you need a
   [Vim with Ruby support](VIM.md).
 
@@ -245,6 +245,17 @@ In such case, your import statements will look something like this:
 ```js
 var Foo = require('foo'); // "declaration_keyword": "var"
 const Foo = require('foo'); // "declaration_keyword": "const"
+```
+
+### `group_imports`
+
+By default, import-js will put imports into groups. The first group consists of
+package dependencies, then one or more groups with internal imports follow. You
+can turn off this behavior by setting `group_imports` to `false`. When
+disabled, imports are listed alphabetically in one list.
+
+```json
+"group_imports": false
 ```
 
 ### `import_dev_dependencies`

--- a/lib/import_js/configuration.rb
+++ b/lib/import_js/configuration.rb
@@ -11,6 +11,7 @@ module ImportJS
     'named_exports' => {},
     'eslint_executable' => 'eslint',
     'excludes' => [],
+    'group_imports' => true,
     'ignore_package_prefixes' => [],
     'import_dev_dependencies' => false,
     'import_function' => 'require',

--- a/lib/import_js/import_statements.rb
+++ b/lib/import_js/import_statements.rb
@@ -121,6 +121,8 @@ module ImportJS
         !import_statement.parsed_and_untouched?
       end.flatten.uniq(&:to_normalized).sort_by(&:to_normalized)
 
+      return [partitioned] unless @config.get('group_imports')
+
       package_dependencies = @config.package_dependencies
       partitioned.each do |import_statement|
         # Figure out what group to put this import statement in

--- a/spec/import_js/import_statements_spec.rb
+++ b/spec/import_js/import_statements_spec.rb
@@ -140,6 +140,23 @@ describe ImportJS::ImportStatements do
       )
     end
 
+    context 'when `group_imports` is false' do
+      let(:configuration) do
+        {
+          'group_imports' => false,
+        }
+      end
+
+      it 'returns a single, ordered group' do
+        expect(subject.to_a).to eq(
+          [
+            "const bar = require('bar');",
+            "import foo from 'foo';",
+          ]
+        )
+      end
+    end
+
     context 'when one statement is a package dependency' do
       let(:second_import_statement) do
         ImportJS::ImportStatement.parse("import bar from 'bar';")
@@ -205,6 +222,25 @@ describe ImportJS::ImportStatements do
           "const custom = custom('custom');",
         ]
       )
+    end
+
+    context 'when `group_imports` is false' do
+      let(:configuration) do
+        {
+          'group_imports' => false,
+        }
+      end
+
+      it 'returns a single, ordered group' do
+        expect(subject.to_a).to eq(
+          [
+            "const bar = require('bar');",
+            "var baz = require('baz');",
+            "const custom = custom('custom');",
+            "import foo from 'foo';",
+          ]
+        )
+      end
     end
   end
 

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -775,6 +775,25 @@ const sko = customImportFunction('sko');
 foo
             EOS
           end
+
+          context 'and `group_imports` is false' do
+            before do
+              allow_any_instance_of(ImportJS::Configuration)
+                .to receive(:get).with('group_imports')
+                .and_return(false)
+            end
+
+            it 'adds the import and sorts all of them' do
+              expect(subject).to eq(<<-EOS.strip)
+import bar from 'foo/bar';
+import foo from 'bar/foo';
+const sko = customImportFunction('sko');
+import zoo from 'foo/zoo';
+
+foo
+              EOS
+            end
+          end
         end
       end
 
@@ -2415,6 +2434,23 @@ bar
           expect(subject).to eq(<<-EOS.strip)
 import bar, { foo } from 'bar';
 
+import baz from 'app/baz';
+
+bar
+          EOS
+        end
+      end
+
+      context 'and `group_imports` is false' do
+        let(:configuration) do
+          {
+            'group_imports' => false,
+          }
+        end
+
+        it 'sorts imports' do
+          expect(subject).to eq(<<-EOS.strip)
+import bar, { foo } from 'bar';
 import baz from 'app/baz';
 
 bar


### PR DESCRIPTION
This commit adds a new `group_imports` configuration option. By setting
this to false, you make all imports end up in one single group, sorted
alphabetically.

After using the grouping for a while on the Brigade codebase, I've
noticed a few issues:

 - import-js bugs are harder to spot (because we have newlines in
   imports, it's hard to spot where parsing of imports stopped)
 - some imports are hard to know what group to put in. e.g. aliases that
   resolve to something inside a package dependency, but doesn't clearly
   say so.
 - merge mistakes happen because people don't understand why the
   whitespace is there.