### PR TITLE
Add menu items to Sublime to open settings files

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -8,5 +8,38 @@
         "command": "import_js"
       }
     ]
+  },
+
+  {
+    "id": "preferences",
+    "children": [
+      {
+        "caption": "Package Settings",
+        "mnemonic": "P",
+        "id": "package-settings",
+        "children": [
+          {
+            "caption": "ImportJS",
+            "children": [
+              {
+                "caption": "Settings – Default",
+                "command": "open_file",
+                "args": {
+                  "file": "${packages}/ImportJS/ImportJS.sublime-settings"
+                }
+              },
+              {
+                "caption": "Settings – User",
+                "command": "open_file",
+                "args": {
+                  "file": "${packages}/User/ImportJS.sublime-settings"
+                }
+              },
+              { "caption": "-" }
+            ]
+          }
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This is a common convention for Sublime Text plugins and will make it
easier to modify the settings that may be required to get ImportJS
working with Sublime Text.

For some reason if I put the preferences child above the tools child,
the tools menu item no longer shows up, but in this order things are
just fine. I wasn't able to determine why, so I'm just going to roll
with it.

Addresses #220 and #219