### PR TITLE
Make it easier to import Node.js core modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,17 @@ will for a file `foo/bar.js` result in
 import styles from './bar.scss';
 ```
 
+### `environments`
+
+This list of environments control what core modules are available when
+importing. The only supported value right now is `["node"]`, and if you use it
+you automatically make [all the core modules for
+Node](https://nodejs.org/api/modules.html#modules_core_modules) available for
+import-js.
+
+```json
+"environments": ["node"]
+```
 
 ### `named_exports`
 
@@ -250,9 +261,10 @@ const Foo = require('foo'); // "declaration_keyword": "const"
 ### `group_imports`
 
 By default, import-js will put imports into groups. The first group consists of
-package dependencies, then one or more groups with internal imports follow. You
-can turn off this behavior by setting `group_imports` to `false`. When
-disabled, imports are listed alphabetically in one list.
+core modules, then comes package dependencies, then one or more groups with
+internal imports follow. You can turn off this behavior by setting
+`group_imports` to `false`. When disabled, imports are listed alphabetically in
+one list.
 
 ```json
 "group_imports": false

--- a/lib/import_js/configuration.rb
+++ b/lib/import_js/configuration.rb
@@ -9,6 +9,7 @@ module ImportJS
     'aliases' => {},
     'declaration_keyword' => 'import',
     'named_exports' => {},
+    'environments' => [],
     'eslint_executable' => 'eslint',
     'excludes' => [],
     'group_imports' => true,
@@ -86,6 +87,54 @@ module ImportJS
       keys.map do |key|
         package_json[key].keys if package_json[key]
       end.compact.flatten
+    end
+
+    ENVIRONMENT_CORE_MODULES = {
+      'node' => %w[
+        assert
+        buffer
+        child_process
+        cluster
+        console
+        constants
+        crypto
+        dgram
+        dns
+        domain
+        events
+        fs
+        http
+        https
+        module
+        net
+        os
+        path
+        process
+        punycode
+        querystring
+        readline
+        repl
+        stream
+        string_decoder
+        sys
+        timers
+        tls
+        tty
+        url
+        util
+        v8
+        vm
+        zlib
+      ],
+    }.freeze
+
+    # @return [Array<String>]
+    def environment_core_modules
+      result = []
+      get('environments').map do |environment|
+        result.concat(ENVIRONMENT_CORE_MODULES[environment])
+      end
+      result
     end
 
     private

--- a/lib/import_js/importer.rb
+++ b/lib/import_js/importer.rb
@@ -384,6 +384,12 @@ module ImportJS
         matched_modules << js_module if js_module
       end
 
+      @config.environment_core_modules.each do |dep|
+        next unless dep.casecmp(variable_name) == 0
+
+        matched_modules << JSModule.new(import_path: dep)
+      end
+
       # If you have overlapping lookup paths, you might end up seeing the same
       # module to import twice. In order to dedupe these, we remove the module
       # with the longest path

--- a/spec/import_js/configuration_spec.rb
+++ b/spec/import_js/configuration_spec.rb
@@ -159,6 +159,67 @@ describe ImportJS::Configuration do
     end
   end
 
+  describe '.environment_core_modules' do
+    before do
+      allow_any_instance_of(ImportJS::Configuration)
+        .to receive(:get).and_call_original
+      allow_any_instance_of(ImportJS::Configuration)
+        .to receive(:get).with('environments').and_return(environments)
+    end
+
+    context 'with no environments specified' do
+      let(:environments) { [] }
+
+      it 'returns an empty array' do
+        expect(subject.environment_core_modules).to eq([])
+      end
+    end
+
+    context 'in a node environment' do
+      let(:environments) { ['node'] }
+
+      it 'returns node core modules' do
+        expect(subject.environment_core_modules).to eq(
+          %w[
+            assert
+            buffer
+            child_process
+            cluster
+            console
+            constants
+            crypto
+            dgram
+            dns
+            domain
+            events
+            fs
+            http
+            https
+            module
+            net
+            os
+            path
+            process
+            punycode
+            querystring
+            readline
+            repl
+            stream
+            string_decoder
+            sys
+            timers
+            tls
+            tty
+            url
+            util
+            v8
+            vm
+            zlib
+          ]
+        )
+      end
+    end
+  end
   describe '.package_dependencies' do
     let(:package_json) { nil }
 

--- a/spec/import_js/import_statements_spec.rb
+++ b/spec/import_js/import_statements_spec.rb
@@ -194,6 +194,34 @@ describe ImportJS::ImportStatements do
         end
       end
     end
+
+    context 'when one is a package dependency and the other is a core module' do
+      let(:first_import_statement) do
+        ImportJS::ImportStatement.parse("import readline from 'readline';")
+      end
+      let(:second_import_statement) do
+        ImportJS::ImportStatement.parse("import bar from 'bar';")
+      end
+
+      before do
+        allow_any_instance_of(ImportJS::Configuration)
+          .to receive(:package_dependencies)
+          .and_return(['bar'])
+        allow_any_instance_of(ImportJS::Configuration)
+          .to receive(:environment_core_modules)
+          .and_return(['readline'])
+      end
+
+      it 'gives the two statements in different groups, core module on top' do
+        expect(subject.to_a).to eq(
+          [
+            "import readline from 'readline';",
+            '',
+            "import bar from 'bar';",
+          ]
+        )
+      end
+    end
   end
 
   context 'when pushed import statements of all different kinds' do

--- a/spec/import_js/importer_spec.rb
+++ b/spec/import_js/importer_spec.rb
@@ -658,6 +658,26 @@ FooIO
         end
       end
 
+      context 'in a node environment' do
+        let(:word) { 'Readline' }
+        let(:text) { 'Readline' }
+
+        before do
+          allow_any_instance_of(ImportJS::Configuration)
+            .to receive(:get).and_call_original
+          allow_any_instance_of(ImportJS::Configuration)
+            .to receive(:get).with('environments').and_return(['node'])
+        end
+
+        it 'adds an import to the top of the buffer' do
+          expect(subject).to eq(<<-EOS.strip)
+import Readline from 'readline';
+
+Readline
+          EOS
+        end
+      end
+
       context 'when the import resolves to a dependency from package.json' do
         let(:existing_files) { [] }
         let(:package_dependencies) { ['foo-bar'] }


### PR DESCRIPTION
We want people that are in a Node environment to be able to import core
modules (like fs, path, readline) quickly. To do that, we're borrowing
ideas from eslint, where you can configure what environments a project
is using [1]. I decided to use `environments` as the config key instead
of `env`, and use an array of environments instead of a hash (env =>
boolean). That made the config option more consistent with how other
keys are named and used.

Imports for core modules will end up at the top of the imports, in its
own group (above) package dependencies.

Fixes #201

[1]: http://eslint.org/docs/user-guide/configuring#specifying-environments